### PR TITLE
Allow actions to avoid return statement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ export class UsageError extends Error {
   isUsageError: true;
 }
 
+type ExitCode = number | void;
+
 export interface Command {
   validate(validator: Validator): Command;
 
@@ -23,7 +25,7 @@ export interface Command {
   detail(details: string): Command;
   example(description: string, example: string): Command;
 
-  action(action: (env: Environment) => Promise<Number | undefined> | Number | undefined): Command;
+  action(action: (env: Environment) => ExitCode | Promise<ExitCode>): Command;
 }
 
 export class Clipanion {
@@ -44,7 +46,7 @@ export class Clipanion {
 
   check(): void;
 
-  run(argv0: string, argv: Array<string>, opts?: Partial<Environment>): Promise<Number | undefined> | Number | undefined;
+  run(argv0: string, argv: Array<string>, opts?: Partial<Environment>): ExitCode | Promise<ExitCode>;
   runExit(argv0: string, argv: Array<string>, opts?: Partial<Environment>): Promise<void>;
 }
 


### PR DESCRIPTION
Before this PR, actions had to return an exit code or an explicit `undefined`:

```ts
clipanion
  .command('example')
  .action(() => {
    console.log('Hello world');
    return 0;
  });

// or

clipanion
  .command('example')
  .action(() => {
    console.log('Hello world');
    return undefined;
  });
```

After this PR, they can skip the return statement:

```ts
clipanion
  .command('example')
  .action(() => {
    console.log('Hello world');
  });
```

Running such commands still sets `0` as a return code, as expected:

```console
$ node -r ts-node/register run.ts example
Hello world

$ echo $?
0
```
