### PR TITLE
feat: Derive name of positional arguments from property name

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -201,7 +201,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
     static Rest({required = 0}: {required?: number} = {}) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             this.registerDefinition(prototype, command => {
-                command.addRest({required});
+                command.addRest({name: propertyName, required});
             });
 
             this.registerTransformer(prototype, (state, command) => {

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -147,7 +147,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                 });
             } else {
                 this.registerDefinition(prototype, command => {
-                    command.addPositional({required: descriptor.required});
+                    command.addPositional({name: propertyName, required: descriptor.required});
                 });
 
                 this.registerTransformer(prototype, (state, command) => {

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -509,14 +509,14 @@ export class CommandBuilder<Context> {
         }
     }
 
-    addRest({required = 0}: {required?: number} = {}) {
+    addRest({name = 'arg', required = 0}: {name?: string, required?: number} = {}) {
         if (this.arity.extra === undefined)
             throw new Error(`Infinite lists cannot be declared multiple times in the same command`);
         if (this.arity.trailing.length > 0)
             throw new Error(`Infinite lists cannot be declared after the required trailing positional arguments`);
 
         for (let t = 0; t < required; ++t)
-            this.addPositional();
+            this.addPositional({name});
 
         this.arity.extra = undefined;
     }

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -617,7 +617,7 @@ export class CommandBuilder<Context> {
             }
 
             let lastExtraNode = lastLeadingNode;
-            if (this.arity.extra !== undefined && this.arity.extra.length > 0) {
+            if (this.arity.extra === undefined || this.arity.extra.length > 0) {
                 const extraShortcutNode = injectNode(machine, makeNode());
                 registerShortcut(machine, lastLeadingNode, extraShortcutNode);
 

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -458,9 +458,9 @@ export const reducers = {
 // ------------------------------------------------------------------------
 
 export type ArityDefinition = {
-    leading: number;
-    extra: number;
-    trailing: number;
+    leading: string[];
+    extra: string[] | undefined;
+    trailing: string[];
     proxy: boolean;
 };
 
@@ -475,7 +475,7 @@ export class CommandBuilder<Context> {
     public readonly cliOpts: Readonly<CliOptions>;
 
     private readonly allOptionNames: string[] = [];
-    private readonly arity: ArityDefinition = {leading: 0, trailing: 0, extra: 0, proxy: false};
+    private readonly arity: ArityDefinition = {leading: [], trailing: [], extra: [], proxy: false};
     private readonly options: OptDefinition[] = [];
     private readonly paths: string[][] = [];
 
@@ -494,31 +494,31 @@ export class CommandBuilder<Context> {
         Object.assign(this.arity, {leading, trailing, extra, proxy});
     }
 
-    addPositional({required = true}: {required?: boolean} = {}) {
-        if (!required && this.arity.extra === Infinity)
+    addPositional({name = 'arg', required = true}: {name?: string, required?: boolean} = {}) {
+        if (!required && this.arity.extra === undefined)
             throw new Error(`Optional parameters cannot be declared when using .rest() or .proxy()`);
-        if (!required && this.arity.trailing > 0)
+        if (!required && this.arity.trailing.length > 0)
             throw new Error(`Optional parameters cannot be declared after the required trailing positional arguments`);
 
-        if (!required) {
-            this.arity.extra += 1;
-        } else if (this.arity.extra === 0) {
-            this.arity.leading += 1;
+        if (!required && this.arity.extra !== undefined) {
+            this.arity.extra.push(name);
+        } else if (this.arity.extra !== undefined && this.arity.extra.length === 0) {
+            this.arity.leading.push(name);
         } else {
-            this.arity.trailing += 1;
+            this.arity.trailing.push(name);
         }
     }
 
     addRest({required = 0}: {required?: number} = {}) {
-        if (this.arity.extra === Infinity)
+        if (this.arity.extra === undefined)
             throw new Error(`Infinite lists cannot be declared multiple times in the same command`);
-        if (this.arity.trailing > 0)
+        if (this.arity.trailing.length > 0)
             throw new Error(`Infinite lists cannot be declared after the required trailing positional arguments`);
 
         for (let t = 0; t < required; ++t)
             this.addPositional();
 
-        this.arity.extra = Infinity;
+        this.arity.extra = undefined;
     }
 
     addProxy() {
@@ -554,17 +554,14 @@ export class CommandBuilder<Context> {
                 segments.push(`[${names.join(`,`)}${args.join(``)}]`);
             }
 
-            for (let t = 0; t < this.arity.leading; ++t)
-                segments.push(`<arg>`);
+            segments.push(...this.arity.leading.map(name => `<${name}>`))
 
-            if (this.arity.extra === Infinity)
+            if (this.arity.extra === undefined)
                 segments.push(`...`);
-            else for (let t = 0; t < this.arity.extra; ++t)
-                segments.push(`[arg]`);
+            else 
+                segments.push(...this.arity.extra.map(name => `[${name}]`))
 
-            for (let t = 0; t < this.arity.trailing; ++t) {
-                segments.push(`<arg>`);
-            }
+            segments.push(...this.arity.trailing.map(name => `<${name}>`))
         }
 
         return segments.join(` `);
@@ -596,7 +593,7 @@ export class CommandBuilder<Context> {
                 lastPathNode = nextPathNode;
             }
 
-            if (this.arity.leading > 0 || !this.arity.proxy) {
+            if (this.arity.leading.length > 0 || !this.arity.proxy) {
                 const helpNode = injectNode(machine, makeNode());
                 registerDynamic(machine, lastPathNode, `isHelp`, helpNode, [`useHelp`, this.cliIndex]);
                 registerStatic(machine, helpNode, END_OF_INPUT, NODE_SUCCESS, [`setSelectedIndex`, HELP_COMMAND_INDEX]);
@@ -604,15 +601,15 @@ export class CommandBuilder<Context> {
 
             this.registerOptions(machine, lastPathNode);
 
-            if (this.arity.leading > 0)
+            if (this.arity.leading.length > 0)
                 registerStatic(machine, lastPathNode, END_OF_INPUT, NODE_ERRORED, [`setError`, `Not enough positional arguments`]);
 
             let lastLeadingNode = lastPathNode;
-            for (let t = 0; t < this.arity.leading; ++t) {
+            for (let t = 0; t < this.arity.leading.length; ++t) {
                 const nextLeadingNode = injectNode(machine, makeNode());
                 this.registerOptions(machine, nextLeadingNode);
 
-                if (this.arity.trailing > 0 || t + 1 !== this.arity.leading)
+                if (this.arity.trailing.length > 0 || t + 1 !== this.arity.leading.length)
                     registerStatic(machine, nextLeadingNode, END_OF_INPUT, NODE_ERRORED, [`setError`, `Not enough positional arguments`]);
 
                 registerDynamic(machine, lastLeadingNode, `isNotOptionLike`, nextLeadingNode, `pushPositional`);
@@ -620,11 +617,11 @@ export class CommandBuilder<Context> {
             }
 
             let lastExtraNode = lastLeadingNode;
-            if (this.arity.extra > 0) {
+            if (this.arity.extra !== undefined && this.arity.extra.length > 0) {
                 const extraShortcutNode = injectNode(machine, makeNode());
                 registerShortcut(machine, lastLeadingNode, extraShortcutNode);
 
-                if (this.arity.extra === Infinity) {
+                if (this.arity.extra === undefined) {
                     const extraNode = injectNode(machine, makeNode());
                     this.registerOptions(machine, extraNode);
 
@@ -632,7 +629,7 @@ export class CommandBuilder<Context> {
                     registerDynamic(machine, extraNode, positionalArgument, extraNode, `pushExtra`);
                     registerShortcut(machine, extraNode, extraShortcutNode);
                 } else {
-                    for (let t = 0; t < this.arity.extra; ++t) {
+                    for (let t = 0; t < this.arity.extra.length; ++t) {
                         const nextExtraNode = injectNode(machine, makeNode());
                         this.registerOptions(machine, nextExtraNode);
 
@@ -645,15 +642,15 @@ export class CommandBuilder<Context> {
                 lastExtraNode = extraShortcutNode;
             }
 
-            if (this.arity.trailing > 0)
+            if (this.arity.trailing.length > 0)
                 registerStatic(machine, lastExtraNode, END_OF_INPUT, NODE_ERRORED, [`setError`, `Not enough positional arguments`]);
 
             let lastTrailingNode = lastExtraNode;
-            for (let t = 0; t < this.arity.trailing; ++t) {
+            for (let t = 0; t < this.arity.trailing.length; ++t) {
                 const nextTrailingNode = injectNode(machine, makeNode());
                 this.registerOptions(machine, nextTrailingNode);
 
-                if (t + 1 < this.arity.trailing)
+                if (t + 1 < this.arity.trailing.length)
                     registerStatic(machine, nextTrailingNode, END_OF_INPUT, NODE_ERRORED, [`setError`, `Not enough positional arguments`]);
 
                 registerDynamic(machine, lastTrailingNode, `isNotOptionLike`, nextTrailingNode, `pushPositional`);

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -456,10 +456,10 @@ export const reducers = {
 };
 
 // ------------------------------------------------------------------------
-
+export const NoLimits = Symbol();
 export type ArityDefinition = {
     leading: string[];
-    extra: string[] | undefined;
+    extra: string[] | typeof NoLimits;
     trailing: string[];
     proxy: boolean;
 };
@@ -500,9 +500,9 @@ export class CommandBuilder<Context> {
         if (!required && this.arity.trailing.length > 0)
             throw new Error(`Optional parameters cannot be declared after the required trailing positional arguments`);
 
-        if (!required && this.arity.extra !== undefined) {
+        if (!required && this.arity.extra !== NoLimits) {
             this.arity.extra.push(name);
-        } else if (this.arity.extra !== undefined && this.arity.extra.length === 0) {
+        } else if (this.arity.extra !== NoLimits && this.arity.extra.length === 0) {
             this.arity.leading.push(name);
         } else {
             this.arity.trailing.push(name);
@@ -518,7 +518,7 @@ export class CommandBuilder<Context> {
         for (let t = 0; t < required; ++t)
             this.addPositional({name});
 
-        this.arity.extra = undefined;
+        this.arity.extra = NoLimits;
     }
 
     addProxy() {
@@ -556,7 +556,7 @@ export class CommandBuilder<Context> {
 
             segments.push(...this.arity.leading.map(name => `<${name}>`))
 
-            if (this.arity.extra === undefined)
+            if (this.arity.extra === NoLimits)
                 segments.push(`...`);
             else 
                 segments.push(...this.arity.extra.map(name => `[${name}]`))
@@ -617,11 +617,11 @@ export class CommandBuilder<Context> {
             }
 
             let lastExtraNode = lastLeadingNode;
-            if (this.arity.extra === undefined || this.arity.extra.length > 0) {
+            if (this.arity.extra === NoLimits || this.arity.extra.length > 0) {
                 const extraShortcutNode = injectNode(machine, makeNode());
                 registerShortcut(machine, lastLeadingNode, extraShortcutNode);
 
-                if (this.arity.extra === undefined) {
+                if (this.arity.extra === NoLimits) {
                     const extraNode = injectNode(machine, makeNode());
                     this.registerOptions(machine, extraNode);
 

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -495,7 +495,7 @@ export class CommandBuilder<Context> {
     }
 
     addPositional({name = 'arg', required = true}: {name?: string, required?: boolean} = {}) {
-        if (!required && this.arity.extra === undefined)
+        if (!required && this.arity.extra === NoLimits)
             throw new Error(`Optional parameters cannot be declared when using .rest() or .proxy()`);
         if (!required && this.arity.trailing.length > 0)
             throw new Error(`Optional parameters cannot be declared after the required trailing positional arguments`);
@@ -510,7 +510,7 @@ export class CommandBuilder<Context> {
     }
 
     addRest({name = 'arg', required = 0}: {name?: string, required?: number} = {}) {
-        if (this.arity.extra === undefined)
+        if (this.arity.extra === NoLimits)
             throw new Error(`Infinite lists cannot be declared multiple times in the same command`);
         if (this.arity.trailing.length > 0)
             throw new Error(`Infinite lists cannot be declared after the required trailing positional arguments`);

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -194,4 +194,20 @@ describe(`Advanced`, () => {
 
         expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <workspaceName> [extra] <scriptName>\n`);
     });
+
+    it.only(`derives rest argument names from the property name`, async () => {
+        class CommandA extends Command {
+            @Command.Rest({required: 2})
+            workspaceNames!: string;
+
+            @Command.Path(`clean`)
+            async execute() {
+                throw new Error('not implemented, just testing usage()')
+            }
+        }
+
+        const cli = Cli.from([CommandA])
+
+        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... clean <workspaceNames> <workspaceNames> ...\n`);
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -172,4 +172,20 @@ describe(`Advanced`, () => {
 
         expect(output).to.equal(`Running CommandB\n"hello"\n`);
     });
+
+    it.only(`derives positional argument names from the fiel name`, async () => {
+        class CommandA extends Command {
+            @Command.String()
+            workspaceName!: string;
+
+            @Command.Path(`workspace`)
+            async execute() {
+                log(this, [`workspaceName`]);
+            }
+        }
+
+        const cli = Cli.from([CommandA])
+
+        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <arg>\n`);
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -152,7 +152,7 @@ describe(`Advanced`, () => {
         expect(output).to.equal(`Running CommandA\nRunning CommandB\n`);
     });
 
-    it.only(`should support inheritance`, async () => {
+    it(`should support inheritance`, async () => {
         const output = await runCli(() => {
             abstract class CommandA extends Command {
                 @Command.String(`--foo`)
@@ -173,7 +173,7 @@ describe(`Advanced`, () => {
         expect(output).to.equal(`Running CommandB\n"hello"\n`);
     });
 
-    it.only(`derives positional argument names from the property name`, async () => {
+    it(`derives positional argument names from the property name`, async () => {
         class CommandA extends Command {
             @Command.String()
             workspaceName!: string;
@@ -195,7 +195,7 @@ describe(`Advanced`, () => {
         expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <workspaceName> [extra] <scriptName>\n`);
     });
 
-    it.only(`derives rest argument names from the property name`, async () => {
+    it(`derives rest argument names from the property name`, async () => {
         class CommandA extends Command {
             @Command.Rest({required: 2})
             workspaceNames!: string;

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -173,19 +173,19 @@ describe(`Advanced`, () => {
         expect(output).to.equal(`Running CommandB\n"hello"\n`);
     });
 
-    it.only(`derives positional argument names from the fiel name`, async () => {
+    it.only(`derives positional argument names from the property name`, async () => {
         class CommandA extends Command {
             @Command.String()
             workspaceName!: string;
 
             @Command.Path(`workspace`)
             async execute() {
-                log(this, [`workspaceName`]);
+                throw new Error('not implemented, just testing usage()')
             }
         }
 
         const cli = Cli.from([CommandA])
 
-        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <arg>\n`);
+        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <workspaceName>\n`);
     });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -178,6 +178,12 @@ describe(`Advanced`, () => {
             @Command.String()
             workspaceName!: string;
 
+            @Command.String({required: false})
+            extra!: string;
+
+            @Command.String()
+            scriptName!: string;
+
             @Command.Path(`workspace`)
             async execute() {
                 throw new Error('not implemented, just testing usage()')
@@ -186,6 +192,6 @@ describe(`Advanced`, () => {
 
         const cli = Cli.from([CommandA])
 
-        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <workspaceName>\n`);
+        expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... workspace <workspaceName> [extra] <scriptName>\n`);
     });
 });


### PR DESCRIPTION
Ref: https://github.com/yarnpkg/berry/pull/371#discussion_r316198410

Nice-to-have?:
- ~[ ] hyphenate names~
- ~[ ] make name configurable `@Command.String({ name: 'workspace-name' })` or `@Command.String('workspace-name')`. Though the second variant requires more work since the library currently assumes that named arguments are optional.~