### PR TITLE
 fix(core): throw error when writing bound boolean arguments 

### DIFF
--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -457,6 +457,25 @@ describe(`Core`, () => {
         ]);
     });
 
+    it(`should support rest arguments between mandatory arguments`, () => {
+        const cli = makeCli([
+            b => {
+                b.addPositional();
+                b.addRest();
+                b.addPositional();
+            },
+        ]);
+
+        const {positionals} = cli.process([`foo`, `src1`, `src2`, `src3`, `dest`]);
+        expect(positionals).to.deep.equal([
+            {value: `foo`, extra: false},
+            {value: `src1`, extra: true},
+            {value: `src2`, extra: true},
+            {value: `src3`, extra: true},
+            {value: `dest`, extra: false},
+        ]);
+    });
+
     it(`should support option arguments in between rest arguments`, () => {
         const cli = makeCli([
             b => {
@@ -466,7 +485,7 @@ describe(`Core`, () => {
             },
         ]);
 
-        const {options, positionals} = cli.process([`--foo`, `src1`, `src2`, `--bar`, `baz`, `src3`]);
+        const {options, positionals} = cli.process([`src1`, `--foo`, `src2`, `--bar`, `baz`, `src3`]);
 
         expect(options).to.deep.equal([
             {name: `--foo`, value: true},


### PR DESCRIPTION
**What's the problem this PR addresses?**

It is currently possible to do `yarn add foo --dev=something`, where `--dev` is a boolean option. This causes `--dev` to be `'something'` at runtime.

**How did you fix it?**

I made the `isBoundOption` function also check if the `arity` is `1`.

I also added a test for this feature, and a few other tests for some other awesome Clipanion features that didn't seem to have a corresponding test. 🙂

BTW, it would be nice having automated CI running on this repo, to boost my confidence that the tests I added are passing. :P