### PR TITLE
Command: Add support for String commands that can act as boolean flags too

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Specifies that the command accepts a positional argument. By default it will be 
 
 ```ts
 class RunCommand extends Command {
-    @Command.String(`--inspect`, { tolerateBoolean = true })
+    @Command.String(`--inspect`, { tolerateBoolean: true })
     public debug: boolean | string = false;
     // ...
 }

--- a/README.md
+++ b/README.md
@@ -120,15 +120,15 @@ async execute() {
 }
 ```
 
-#### `@Command.String({required?: boolean, booleanIfNotBound?: boolean})`
+#### `@Command.String({required?: boolean, tolerateBoolean?: boolean})`
 
 Specifies that the command accepts a positional argument. By default it will be required, but this can be toggled off.
 
-`booleanIfNotBound` specifies that the command will act like a boolean flag if it doesn't have a value. With this option on, an argument value can only be specified using `=`. It is off by default.
+`tolerateBoolean` specifies that the command will act like a boolean flag if it doesn't have a value. With this option on, an argument value can only be specified using `=`. It is off by default.
 
 ```ts
 class RunCommand extends Command {
-    @Command.String(`--inspect`, { booleanIfNotBound = true })
+    @Command.String(`--inspect`, { tolerateBoolean = true })
     public debug: boolean | string = false;
     // ...
 }

--- a/README.md
+++ b/README.md
@@ -120,9 +120,28 @@ async execute() {
 }
 ```
 
-#### `@Command.String({required?: boolean})`
+#### `@Command.String({required?: boolean, booleanIfNotBound?: boolean})`
 
 Specifies that the command accepts a positional argument. By default it will be required, but this can be toggled off.
+
+`booleanIfNotBound` specifies that the command will act like a boolean flag if it doesn't have a value. With this option on, an argument value can only be specified using `=`. It is off by default.
+
+```ts
+class RunCommand extends Command {
+    @Command.String(`--inspect`, { booleanIfNotBound = true })
+    public debug: boolean | string = false;
+    // ...
+}
+
+run --inspect
+=> debug = true
+
+run --inspect=1234
+=> debug = "1234"
+
+run --inspect 1234
+=> invalid
+```
 
 #### `@Command.String(optionNames: string)`
 

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -163,7 +163,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      * Note that all methods affecting positional arguments are evaluated in the definition order; don't mess with it (for example sorting your properties in ascendent order might have adverse results).
      * @param descriptor The option names.
      */
-    static String(descriptor: string, opts?: {booleanIfNotBound?: boolean, hidden?: boolean}): PropertyDecorator;
+    static String(descriptor: string, opts?: {tolerateBoolean?: boolean, hidden?: boolean}): PropertyDecorator;
 
     /**
      * Register a listener that looks for positional arguments. When Clipanion detects that an argument isn't an option, it will put it in this property and continue processing the rest of the command line.
@@ -172,15 +172,15 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      */
     static String(descriptor?: {required: boolean}): PropertyDecorator;
 
-    static String(descriptor: string | {required: boolean} = {required: true}, {booleanIfNotBound = false, hidden = false}: {booleanIfNotBound?: boolean, hidden?: boolean} = {}) {
+    static String(descriptor: string | {required: boolean} = {required: true}, {tolerateBoolean = false, hidden = false}: {tolerateBoolean?: boolean, hidden?: boolean} = {}) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             if (typeof descriptor === `string`) {
                 const optNames = descriptor.split(`,`);
 
                 this.registerDefinition(prototype, command => {
-                    // If booleanIfNotBound is specified, the command will only accept a string value
+                    // If tolerateBoolean is specified, the command will only accept a string value
                     // using the bind syntax and will otherwise act like a boolean option
-                    command.addOption({names: optNames, arity: booleanIfNotBound ? 0 : 1, hidden});
+                    command.addOption({names: optNames, arity: tolerateBoolean ? 0 : 1, hidden});
                 });
 
                 this.registerTransformer(prototype, (state, command) => {

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -144,7 +144,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
             const optNames = descriptor.split(`,`);
 
             this.registerDefinition(prototype, command => {
-                command.addOption({names: optNames, arity: 0, hidden});
+                command.addOption({names: optNames, arity: 0, hidden, allowBinding: false});
             });
 
             this.registerTransformer(prototype, (state, command) => {
@@ -163,7 +163,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      * Note that all methods affecting positional arguments are evaluated in the definition order; don't mess with it (for example sorting your properties in ascendent order might have adverse results).
      * @param descriptor The option names.
      */
-    static String(descriptor: string, opts?: {hidden?: boolean}): PropertyDecorator;
+    static String(descriptor: string, opts?: {booleanIfNotBound?: boolean, hidden?: boolean}): PropertyDecorator;
 
     /**
      * Register a listener that looks for positional arguments. When Clipanion detects that an argument isn't an option, it will put it in this property and continue processing the rest of the command line.
@@ -172,13 +172,15 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      */
     static String(descriptor?: {required: boolean}): PropertyDecorator;
 
-    static String(descriptor: string | {required: boolean} = {required: true}, {hidden = false}: {hidden?: boolean} = {}) {
+    static String(descriptor: string | {required: boolean} = {required: true}, {booleanIfNotBound = false, hidden = false}: {booleanIfNotBound?: boolean, hidden?: boolean} = {}) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             if (typeof descriptor === `string`) {
                 const optNames = descriptor.split(`,`);
 
                 this.registerDefinition(prototype, command => {
-                    command.addOption({names: optNames, arity: 1, hidden});
+                    // If booleanIfNotBound is specified, the command will only accept a string value
+                    // using the bind syntax and will otherwise act like a boolean option
+                    command.addOption({names: optNames, arity: booleanIfNotBound ? 0 : 1, hidden});
                 });
 
                 this.registerTransformer(prototype, (state, command) => {

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -542,8 +542,8 @@ export const tests = {
     isBoundOption: (state: RunState, segment: string, names: string[], options: OptDefinition[]) => {
         const optionParsing = segment.match(BINDING_REGEX);
         return !state.ignoreOptions && !!optionParsing && OPTION_REGEX.test(optionParsing[1]) && names.includes(optionParsing[1])
-          // Disallow bound options with no arguments (i.e. booleans)
-          && options.filter(opt => opt.names.includes(optionParsing[1])).every(opt => opt.arity !== 0);
+            // Disallow bound options with no arguments (i.e. booleans)
+            && options.filter(opt => opt.names.includes(optionParsing[1])).every(opt => opt.allowBinding);
     },
     isNegatedOption: (state: RunState, segment: string, name: string) => {
         return !state.ignoreOptions && segment === `--no-${name.slice(2)}`;
@@ -633,6 +633,7 @@ export type OptDefinition = {
     names: string[];
     arity: 1 | 0;
     hidden: boolean;
+    allowBinding: boolean;
 };
 
 export class CommandBuilder<Context> {
@@ -691,9 +692,9 @@ export class CommandBuilder<Context> {
         this.arity.proxy = true;
     }
 
-    addOption({names, arity = 0, hidden = false}: Partial<OptDefinition> & {names: string[]}) {
+    addOption({names, arity = 0, hidden = false, allowBinding = true}: Partial<OptDefinition> & {names: string[]}) {
         this.allOptionNames.push(...names);
-        this.options.push({names, arity, hidden});
+        this.options.push({names, arity, hidden, allowBinding});
     }
 
     setContext(context: Context) {

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -250,4 +250,25 @@ describe(`Advanced`, () => {
 
         expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... clean <workspaceNames> <workspaceNames> ...\n`);
     });
+
+    it(`supports strings that act like booleans if not bound to a value`, async () => {
+        const commandGenerator = () => {
+            class CommandA extends Command {
+                @Command.String(`--break`, { booleanIfNotBound: true })
+                enableDebugger: boolean | string = false;
+
+                async execute() {
+                    log(this, [`enableDebugger`]);
+                }
+            }
+            return [
+                CommandA,
+            ];
+        };
+
+        expect(await runCli(commandGenerator, [])).to.equal(`Running CommandA\nfalse\n`);
+        expect(await runCli(commandGenerator, [`--break`])).to.equal(`Running CommandA\ntrue\n`);
+        expect(await runCli(commandGenerator, [`--break=1234`])).to.equal(`Running CommandA\n"1234"\n`);
+        await expect(runCli(commandGenerator, [`--break`, `1234`])).to.be.rejectedWith(Error);
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -253,7 +253,7 @@ describe(`Advanced`, () => {
 
     it(`supports strings that act like booleans if not bound to a value`, async () => {
         class CommandA extends Command {
-            @Command.String(`--break`, { booleanIfNotBound: true })
+            @Command.String(`--break`, { tolerateBoolean: true })
             enableDebugger: boolean | string = false;
 
             async execute() {
@@ -262,7 +262,7 @@ describe(`Advanced`, () => {
         }
 
         class InvertedCommandA extends Command {
-            @Command.String(`--break`, { booleanIfNotBound: true })
+            @Command.String(`--break`, { tolerateBoolean: true })
             enableDebugger: boolean | string = true;
 
             async execute() {

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -277,6 +277,7 @@ describe(`Advanced`, () => {
         expect(cli.process([`--no-break`])).to.contain({enableDebugger: false});
         expect(cli.process([`--break=1234`])).to.contain({enableDebugger: "1234"});
         expect(() => { cli.process([`--break`, `1234`])}).to.throw(Error);
+        expect(() => { cli.process([`--no-break=1234`])}).to.throw(Error);
 
         cli = Cli.from([InvertedCommandA])
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -373,7 +373,7 @@ describe(`Core`, () => {
     it(`should extract strings from complex options (=)`, () => {
         const cli = makeCli([
             b => {
-                b.addOption({names: [`--foo`], arity: 0});
+                b.addOption({names: [`--foo`], arity: 1});
             },
         ]);
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -373,7 +373,7 @@ describe(`Core`, () => {
     it(`should extract strings from complex options (=)`, () => {
         const cli = makeCli([
             b => {
-                b.addOption({names: [`--foo`], arity: 1});
+                b.addOption({names: [`--foo`], arity: 0});
             },
         ]);
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -747,7 +747,7 @@ describe(`Core`, () => {
     it(`should throw acceptable errors when writing bound boolean arguments`, () => {
         const cli = makeCli([
             b => {
-                b.addOption({names: [`--foo`]});
+                b.addOption({names: [`--foo`], allowBinding: false});
             },
         ]);
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

There is no official support for having arguments that can only get a value via binding (`--x=y`) and fallback on being a boolean flag when no value is provided.
This is currently possible but was not intended, and prone to breakage.

A use case can be found here: https://github.com/yarnpkg/berry/pull/1358

**How did you fix it?**

As discussed in https://github.com/yarnpkg/berry/pull/1358 , I added the ability for a Command.String to explicitly support falling back as a boolean flag

I added an advanced end to end test to check that the CLI acts as expected without relying on manual configuration of the Command (which would hide an error in Command.String's constructor)

Note: There is a little overlap between this PR and #14 . At first, I only changed the arity, but merging #14 would have broken this, so I added the explicit option flag.
In my PR, Boolean Commands opt out from being bindable explicitly.
This _may_ be an incomplete reimplementation of what #14 does because I only explicitly excluded booleans.

I believe that #14 should be merged first, then this PR reapplied on top of it, overwriting https://github.com/arcanis/clipanion/pull/14/commits/82d1fe72faf3730ee48ba4387a69176cffdf3265#diff-5aefe378e0204c7252a8e3f584db20c8R546 . #14 's tests should then break, and should be patched with `allowBinding: false`.