### PR TITLE
feat: expose binary information on the MiniCli

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -19,6 +19,9 @@ export type CliContext<Context extends BaseContext> = {
 };
 
 export type MiniCli<Context extends BaseContext> = {
+    binaryLabel?: string;
+    binaryName: string;
+    binaryVersion?: string;
     definitions(): Object;
     error(error: Error, opts?: {command?: Command<Context> | null}): string;
     process(input: string[]): Command<Context>;
@@ -116,6 +119,9 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
 
         command.context = context;
         command.cli = {
+            binaryLabel: this.binaryLabel,
+            binaryName: this.binaryName,
+            binaryVersion: this.binaryVersion,
             definitions: () => this.definitions(),
             error: (error, opts) => this.error(error, opts),
             process: input => this.process(input),

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -17,7 +17,7 @@ export type BaseContext = {
     /**
      * The input stream of the CLI.
      *
-     * @example
+     * @default
      * process.stdin
      */
     stdin: Readable;
@@ -25,7 +25,7 @@ export type BaseContext = {
     /**
      * The output stream of the CLI.
      *
-     * @example
+     * @default
      * process.stdout
      */
     stdout: Writable;
@@ -33,7 +33,7 @@ export type BaseContext = {
     /**
      * The error stream of the CLI.
      *
-     * @example
+     * @default
      * process.stderr
      */
     stderr: Writable;
@@ -238,7 +238,10 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
     /**
      * Runs a command and exits the current `process` with the exit code returned by the command.
      *
-     * @param input An array containing the name of the command and its arguments. You probably want to use `process.argv.slice(2)`.
+     * @param input An array containing the name of the command and its arguments.
+     *
+     * @example
+     * cli.runExit(process.argv.slice(2), Cli.defaultContext)
      */
     async runExit(input: Command<Context> | string[], context: Context) {
         process.exitCode = await this.run(input, context);

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -7,11 +7,55 @@ export type Meta<Context extends BaseContext> = {
     transformers: ((state: RunState, command: Command<Context>) => void)[];
 };
 
+/**
+ * The usage of a Command.
+ */
 export type Usage = {
+    /**
+     * The category of the command.
+     *
+     * Included in the detailed usage.
+     */
     category?: string;
+
+    /**
+     * The short description of the command, formatted as Markdown.
+     *
+     * Included in the detailed usage.
+     */
     description?: string;
+
+    /**
+     * The extended details of the command, formatted as Markdown.
+     *
+     * Included in the detailed usage.
+     */
     details?: string;
+
+    /**
+     * Examples of the command represented as an Array of tuples.
+     *
+     * The first element of the tuple represents the description of the example.
+     *
+     * The second element of the tuple represents the command of the example.
+     * If present, the leading `$0` is replaced with `cli.binaryName`.
+     */
     examples?: [string, string][];
+};
+
+/**
+ * The definition of a Command.
+ */
+export type Definition = Usage & {
+    /**
+     * The path of the command, starting with `cli.binaryName`.
+     */
+    path: string;
+
+    /**
+     * The detailed usage of the command.
+     */
+    usage: string;
 };
 
 export type CommandClass<Context extends BaseContext = BaseContext> = {

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -1,4 +1,4 @@
-export {BaseContext, Cli}             from './Cli';
-export {CommandClass, Command, Usage} from './Command';
+export {BaseContext, Cli}                         from './Cli';
+export {CommandClass, Command, Usage, Definition} from './Command';
 
-export {UsageError}                   from '../errors';
+export {UsageError}                               from '../errors';

--- a/sources/errors.ts
+++ b/sources/errors.ts
@@ -6,6 +6,11 @@ export type ErrorMeta = {
     type: `usage`;
 };
 
+/**
+ * A generic usage error with the name `UsageError`.
+ *
+ * It should be used over `Error` only when it's the user's fault.
+ */
 export class UsageError extends Error {
     public clipanion: ErrorMeta = {type: `usage`};
 

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -147,6 +147,27 @@ describe(`Advanced`, () => {
         expect(output).not.to.equal(`$0`);
     });
 
+    it(`should expose binary information on the MiniCli`, async () => {
+        const binaryInfo = {
+            binaryLabel: `My CLI`,
+            binaryName: `my-cli`,
+            binaryVersion: `1.0.0`,
+        };
+        const cli = new Cli(binaryInfo);
+
+        cli.register(
+            class CommandA extends Command {
+                async execute() {
+                    this.context.stdout.write(JSON.stringify(this.cli));
+                }
+            }
+        );
+
+        const output = await runCli(cli, []);
+
+        expect(JSON.parse(output)).to.contain(binaryInfo);
+    });
+
     it(`should allow calling a command from another`, async () => {
         const output = await runCli(() => {
             class CommandA extends Command {


### PR DESCRIPTION
**What's the problem this PR addresses?**

The binary information (`binaryLabel`, `binaryName`, and `binaryVersion`) isn't exposed on the `MiniCli`.
It would be useful for things like `-v,--version` commands to just do `this.context.stdout.write(this.cli.binaryVersion);`, rather than `this.context.stdout.write(THE_COMPLEX_WAY_THE_VERSION_IS_COMPUTED_THAT_I_ALREADY_USE_IN_THE_CLI_ENTRY_POINT_FILE);`. 

**How did you fix it?**

I made the binary information be exposed on the MiniCli.

---

@arcanis BTW, would you be open to shipping the common command entries (`-v,--version` and `-h,--help`) directly in Clipanion (they would have to be manually registered by the user)?:

```ts
import {VersionEntry, HelpEntry} from 'clipanion';

// ...

cli.register(VersionEntry);
cli.register(HelpEntry);
```

It's getting tedious to have to write them for each new CLI we create and they're also quite common use-cases. (I don't know any examples of popular CLIs that don't have version and help entries).

They would just be:

```ts
import {Command} from 'clipanion';

export default class HelpEntry extends Command {
  @Command.Path(`--help`)
  @Command.Path(`-h`)
  async execute() {
    this.context.stdout.write(this.cli.usage(null));
  }
}
```

and

```ts
import {Command} from 'clipanion';

export default class VersionCommand extends Command {
  @Command.Path(`--version`)
  @Command.Path(`-v`)
  async execute() {
    this.context.stdout.write(`${this.cli.binaryVersion ?? `<unknown>`}\n`);
  }
}
```