### PR TITLE
feat: typed schema

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -69,7 +69,7 @@ export type Definition = Usage & {
  *   b: yup.number().integer(),
  * })
  */
-export type Schema<C extends Command<any> = Command<any>> = {
+export type Schema<C extends Command<any>> = {
     /**
      * A function that takes the `Command` instance as a parameter and validates it, throwing an Error if the validation fails.
      */
@@ -307,7 +307,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      * Defines the schema for the given command.
      * @param schema
      */
-    static Schema<C extends Command<any> = Command<any>>(schema: Schema<C>) {
+    static Schema<C extends Command<any> = Command<BaseContext>>(schema: Schema<C>) {
         return schema;
     }
 

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -14,10 +14,28 @@ export type Usage = {
     examples?: [string, string][];
 };
 
+/**
+ * The schema used to validate the Command instance.
+ *
+ * The easiest way to validate it is by using the [Yup](https://github.com/jquense/yup) library.
+ *
+ * @example
+ * yup.object().shape({
+ *   a: yup.number().integer(),
+ *   b: yup.number().integer(),
+ * })
+ */
+export type Schema<C extends Command<any> = Command<any>> = {
+    /**
+     * A function that takes the `Command` instance as a parameter and validates it, throwing an Error if the validation fails.
+     */
+    validate: (object: C) => void;
+};
+
 export type CommandClass<Context extends BaseContext = BaseContext> = {
     new(): Command<Context>;
     resolveMeta(prototype: Command<Context>): Meta<Context>;
-    schema?: {validate: (object: any) => void};
+    schema?: Schema<any>;
     usage?: Usage;
 };
 
@@ -240,6 +258,19 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      * Contains the usage information for the command. If undefined, the command will be hidden from the general listing.
      */
     static usage?: Usage;
+
+    /**
+     * Defines the schema for the given command.
+     * @param schema
+     */
+    static Schema<C extends Command<any> = Command<any>>(schema: Schema<C>) {
+        return schema;
+    }
+
+    /**
+     * The schema used to validate the Command instance.
+     */
+    static schema?: Schema<any>;
 
     /**
      * Standard command that'll get executed by `Cli#run` and `Cli#runExit`. Expected to return an exit code or nothing (which Clipanion will treat as if 0 had been returned).

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -1,4 +1,4 @@
-export {BaseContext, Cli}             from './Cli';
-export {CommandClass, Command, Usage} from './Command';
+export {BaseContext, Cli}                     from './Cli';
+export {CommandClass, Command, Usage, Schema} from './Command';
 
-export {UsageError}                   from '../errors';
+export {UsageError}                           from '../errors';


### PR DESCRIPTION
**What's the problem this PR addresses?**

The `schema` static property isn't currently typed, meaning that `static schema = 'foo';` is valid.

**How did you fix it?**

I made the `schema` static property typed. I also made the argument of the `validate` callback somewhat(?) typed.
This way, the Yup integration continues to work exactly as before, but now, even ~~cavemen~~ people that need something different who decide to use a raw `validate` function can still get a typed schema. This also helps possibly integrating other validation libraries with Clipanion.

BTW, all that generic weirdness is necessary. I've tried every other possible combination, but this is the single one that doesn't cause **everything** to break.

```ts
// TS complains
static schema = 'foo';

// TS still complains
static schema = {};

static schema = {
  // command is typed as any :(
  validate(command) {}
};

// The same as `static schema = Command.Schema({...})`
static schema: Schema = {
  // command is typed as Command<any> :|
  validate(command) {}
};

// The same as `static schema = Command.Schema<MyCommand>({...})`
static schema: Schema<MyCommand> = {
  // command is typed as MyCommand :)
  validate(command) {
    // Valid
    command.myArgument;

    // Valid
    command.context.myCustomProperty;
  }
};
```