### PR TITLE
chore: create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Hide .yarn and .vscode/pnpify from GitHub's language detection
+/.yarn/**          linguist-vendored
+/.vscode/pnpify/** linguist-vendored


### PR DESCRIPTION
Since I've run `yarn pnpify --sdk`, the repo is showing up as 93.5% JavaScript, when it's actually 100% TypeScript.
I created a `.gitattributes` file to mark the `.vscode/pnpify` folder as `linguist-vendored`.