### PR TITLE
Removes chalk from the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,9 @@
   "version": "2.3.1",
   "main": "sources/advanced/index.ts",
   "license": "MIT",
-  "dependencies": {
-    "chalk": "^4.0.0"
-  },
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/chai-as-promised": "^7.1.2",
-    "@types/chalk": "^2.2.0",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.1",
     "@types/yup": "^0.28.3",

--- a/sources/format.ts
+++ b/sources/format.ts
@@ -1,6 +1,22 @@
-import chalk from 'chalk';
+export interface ColorFormat {
+    bold(str: string): string;
+    error(str: string): string;
+    code(str: string): string;
+};
 
-export function formatMarkdownish(text: string, paragraphs: boolean) {
+export const richFormat: ColorFormat = {
+    bold: str => `\x1b[1m${str}\x1b[22m`,
+    error: str => `\x1b[31m\x1b[1m${str}\x1b[22m\x1b[39m`,
+    code: str => `\x1b[36m${str}\x1b[39m`,
+};
+
+export const textFormat: ColorFormat = {
+    bold: str => str,
+    error: str => str,
+    code: str => str,
+};
+
+export function formatMarkdownish(text: string, {format, paragraphs}: {format: ColorFormat, paragraphs: boolean}) {
     // Enforce \n as newline character
     text = text.replace(/\r\n?/g, `\n`);
 
@@ -34,7 +50,7 @@ export function formatMarkdownish(text: string, paragraphs: boolean) {
 
     // Highlight the code segments
     text = text.replace(/(`+)((?:.|[\n])*?)\1/g, function ($0, $1, $2) {
-        return chalk.cyan($1 + $2 + $1);
+        return format.code($1 + $2 + $1);
     });
 
     return text ? text + `\n` : ``;

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,15 +64,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chalk@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@types/chalk@npm:2.2.0"
-  dependencies:
-    chalk: "*"
-  checksum: 3/9cded9031f180268be59010fc1e13c7b4384e51f0ca8b75bc7a40bdd46f5f3c4859953525fb53663287e5bb25ca5df59396c276ce5c09e1a83aa7a2aec6a9f59
-  languageName: node
-  linkType: hard
-
 "@types/color-name@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/color-name@npm:1.1.1"
@@ -547,7 +538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:*, chalk@npm:^2.0.1":
+"chalk@npm:^2.0.1":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -565,16 +556,6 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: 3/4018b0c812880da595d0d7b8159939527b72f58d3370e2fdc1a24d9abd460bab851695d7eca014082f110d5702d1221b05493fec430ccce375de907d50cc48c1
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "chalk@npm:4.0.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: 3/12b01a228b5ca2f03a82684c62d54c06e2ba2f7b81dd08fac56c5b9288958dd24f9cae866e140df5c29cb736059cb4be0165157ebb0b15039cc1ea511a2dab60
   languageName: node
   linkType: hard
 
@@ -624,14 +605,12 @@ __metadata:
   dependencies:
     "@types/chai": ^4.2.11
     "@types/chai-as-promised": ^7.1.2
-    "@types/chalk": ^2.2.0
     "@types/mocha": ^7.0.2
     "@types/node": ^14.0.1
     "@types/yup": ^0.28.3
     "@yarnpkg/pnpify": ^2.0.0-rc.22
     chai: ^4.2.0
     chai-as-promised: ^7.1.1
-    chalk: ^4.0.0
     get-stream: ^5.1.0
     mocha: ^7.1.2
     ts-node: ^8.10.1


### PR DESCRIPTION
Chalk is a large library that we don't really use. I inlined the few terminal sequences that we actually need, and made it configurable by the user to decide whether they want color or not (with a sensible default based on whether stdout is a TTY, which is the commonly agreed pattern).