### PR TITLE
feat: allow passing Cli options to Cli.from

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -42,28 +42,38 @@ export type CliContext<Context extends BaseContext> = {
     commandClass: CommandClass<Context>;
 };
 
-export type MiniCli<Context extends BaseContext> = {
+export type CliOptions = Readonly<{
     /**
      * The label of the binary.
      *
      * Shown at the top of the usage information.
      */
-    readonly binaryLabel?: string;
+    binaryLabel?: string,
 
     /**
      * The name of the binary.
      *
      * Included in the path and the examples of the definitions.
      */
-    readonly binaryName: string;
+    binaryName: string,
 
     /**
      * The version of the binary.
      *
      * Shown at the top of the usage information.
      */
-    readonly binaryVersion?: string;
+    binaryVersion?: string,
 
+    /**
+     * If `true`, the Cli will use colors in the output.
+     *
+     * @default
+     * process.env.FORCE_COLOR ?? process.stdout.isTTY
+     */
+    enableColors: boolean,
+}>;
+
+export type MiniCli<Context extends BaseContext> = CliOptions & {
     /**
      * Returns an Array representing the definitions of all registered commands.
      */
@@ -149,8 +159,8 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
      * @param commandClasses The Commands to register
      * @returns The created `Cli` instance
      */
-    static from<Context extends BaseContext = BaseContext>(commandClasses: CommandClass<Context>[]) {
-        const cli = new Cli<Context>();
+    static from<Context extends BaseContext = BaseContext>(commandClasses: CommandClass<Context>[], options: Partial<CliOptions> = {}) {
+        const cli = new Cli<Context>(options);
 
         for (const commandClass of commandClasses)
             cli.register(commandClass);
@@ -158,7 +168,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
         return cli;
     }
 
-    constructor({binaryLabel, binaryName: binaryNameOpt = `...`, binaryVersion, enableColors = getDefaultColorSettings()}: {binaryLabel?: string, binaryName?: string, binaryVersion?: string, enableColors?: boolean} = {}) {
+    constructor({binaryLabel, binaryName: binaryNameOpt = `...`, binaryVersion, enableColors = getDefaultColorSettings()}: Partial<CliOptions> = {}) {
         this.builder = new CliBuilder({binaryName: binaryNameOpt});
 
         this.binaryLabel = binaryLabel;
@@ -232,6 +242,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
             binaryLabel: this.binaryLabel,
             binaryName: this.binaryName,
             binaryVersion: this.binaryVersion,
+            enableColors: this.enableColors,
             definitions: () => this.definitions(),
             error: (error, opts) => this.error(error, opts),
             process: input => this.process(input),

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -7,7 +7,7 @@ Command.Entries.Version = VersionCommand
 
 export {Command}
 
-export {BaseContext, Cli}                                 from './Cli';
+export {BaseContext, Cli, CliOptions}                     from './Cli';
 export {CommandClass, Usage, Definition, Schema}          from './Command';
 
 export {UsageError}                                       from '../errors';

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -3,7 +3,7 @@ import chai, {expect}               from 'chai';
 import getStream                    from 'get-stream';
 import {PassThrough}                from 'stream';
 
-import {Cli, CommandClass, Command} from '../sources/advanced';
+import {Cli, CommandClass, Command, CliOptions} from '../sources/advanced';
 
 chai.use(chaiAsPromised);
 
@@ -181,11 +181,12 @@ describe(`Advanced`, () => {
         expect(output).not.to.equal(`$0`);
     });
 
-    it(`should expose binary information on the MiniCli`, async () => {
-        const binaryInfo = {
+    it(`should expose Cli options on the MiniCli`, async () => {
+        const binaryInfo: CliOptions = {
             binaryLabel: `My CLI`,
             binaryName: `my-cli`,
             binaryVersion: `1.0.0`,
+            enableColors: false,
         };
 
         const cli = new Cli(binaryInfo);


### PR DESCRIPTION
This PR makes it possible to pass the Cli options as an argument to `Cli.from`. It also makes it so that all Cli options are exposed on the `MiniCli`.