### PR TITLE
feat: add path to help command

### DIFF
--- a/sources/advanced/HelpCommand.ts
+++ b/sources/advanced/HelpCommand.ts
@@ -9,6 +9,7 @@ export class HelpCommand<Context extends BaseContext> extends Command<Context> {
 
     static from<Context extends BaseContext>(state: RunState, realCli: Cli<Context>, contexts: CliContext<Context>[]) {
         const command = new HelpCommand<Context>(realCli, contexts);
+        command.path = state.path;
 
         for (const opt of state.options) {
             switch (opt.name) {

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -395,11 +395,11 @@ export function selectBestState(input: string[], states: RunState[]) {
 
 export function aggregateHelpStates(states: RunState[]) {
     const notHelps: RunState[] = [];
-    const helps = [];
+    const helps: RunState[] = [];
 
     for (const state of states) {
         if (state.selectedIndex === HELP_COMMAND_INDEX) {
-            helps.push(...state.options);
+            helps.push(state);
         } else {
             notHelps.push(state);
         }
@@ -410,15 +410,26 @@ export function aggregateHelpStates(states: RunState[]) {
             candidateUsage: null,
             errorMessage: null,
             ignoreOptions: false,
-            path: [],
+            path: findCommonPrefix(...helps.map(state => state.path)),
             positionals: [],
-            options: helps,
+            options: helps.reduce((options, state) => options.concat(state.options), [] as RunState['options']),
             remainder: null,
             selectedIndex: HELP_COMMAND_INDEX,
         });
     }
 
     return notHelps;
+}
+
+function findCommonPrefix(...paths: string[][]): string[];
+function findCommonPrefix(firstPath: string[], secondPath: string[]|undefined, ...rest: string[][]): string[] {
+    if (secondPath === undefined)
+        return Array.from(firstPath);
+
+    return findCommonPrefix(
+        firstPath.filter((segment, i) => segment === secondPath[i]),
+        ...rest
+    );
 }
 
 // ------------------------------------------------------------------------

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -52,6 +52,41 @@ const prefix = `\u001b[1m$ \u001b[22m`;
 describe(`Advanced`, () => {
     describe(`Builtin Entries`, () => {
         describe(`help`, () => {
+            it(`should have a path`, async () => {
+                const cli = new Cli();
+
+                class CommandA extends Command {
+                    async execute() {}
+                }
+                cli.register(CommandA);
+
+                class CommandB extends Command {
+                    @Command.Path(`b`)
+                    async execute() {}
+                }
+                cli.register(CommandB);
+
+                class CommandB1 extends Command {
+                    @Command.Path(`b`, `one`)
+                    async execute() {}
+                }
+                cli.register(CommandB1);
+
+                class CommandB2 extends Command {
+                    @Command.Path(`b`, `two`)
+                    async execute() {}
+                }
+                cli.register(CommandB2);
+
+                expect(cli.process([`-h`]).path).to.deep.equal([]);
+
+                cli.register(Command.Entries.Help);
+                expect(cli.process([`-h`]).path).to.deep.equal([`-h`]);
+
+                expect(cli.process([`b`, `--help`]).path).to.deep.equal([`b`]);
+                expect(cli.process([`b`, `one`, `--help`]).path).to.deep.equal([`b`, `one`]);
+            });
+
             it(`should display the usage`, async () => {
                 const cli = new Cli()
                 cli.register(Command.Entries.Help);


### PR DESCRIPTION
The builtin help command currently doesn't have a `path` property, even though the types say the property should exist.

This leads to errors in yarn:

```
$ yarn npm login --help
Type Error: Cannot read property 'join' of undefined
    at exec (/path/to/yarn/packages/yarnpkg-cli/sources/main.ts:111:63)
    at run (/path/to/yarn/packages/yarnpkg-cli/sources/main.ts:51:7)
```

Alternatively, the type of Cli.process could be modified to include the fact that it could return a command instance without path.