### PR TITLE
feat: allow a pretty name to be passed for positional arguments

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -191,9 +191,9 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      * Note that all methods affecting positional arguments are evaluated in the definition order; don't mess with it (for example sorting your properties in ascendent order might have adverse results).
      * @param descriptor Whether or not filling the positional argument is required for the command to be a valid selection.
      */
-    static String(descriptor?: {required: boolean}): PropertyDecorator;
+    static String(descriptor?: {required?: boolean; name?: string}): PropertyDecorator;
 
-    static String(descriptor: string | {required: boolean} = {required: true}, {tolerateBoolean = false, hidden = false}: {tolerateBoolean?: boolean, hidden?: boolean} = {}) {
+    static String(descriptor: string | {required?: boolean, name?: string} = {}, {tolerateBoolean = false, hidden = false}: {tolerateBoolean?: boolean, hidden?: boolean} = {}) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             if (typeof descriptor === `string`) {
                 const optNames = descriptor.split(`,`);
@@ -214,7 +214,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                 });
             } else {
                 this.registerDefinition(prototype, command => {
-                    command.addPositional({name: propertyName, required: descriptor.required});
+                    command.addPositional({name: descriptor.name ?? propertyName, required: descriptor.required !== false});
                 });
 
                 this.registerTransformer(prototype, (state, command) => {

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -372,4 +372,23 @@ describe(`Advanced`, () => {
             ];
         }, [])).to.be.rejectedWith(`non-error rejection`);
     });
+
+    it(`shouldn't crash when throwing non-error exceptions`, async () => {
+        class CommandA extends Command {
+            @Command.String({name: 'prettyName'})
+            thisNameIsntUsed!: string;
+
+            async execute() {throw 42}
+        }
+
+        const cli = Cli.from([CommandA])
+        const usage = cli.usage(CommandA);
+
+        expect(usage).not.to.contain('thisNameIsntUsed');
+        expect(usage).to.contain('prettyName');
+
+        const command = cli.process(['foo']);
+
+        expect((command as CommandA).thisNameIsntUsed).to.eq('foo');
+    });
 });


### PR DESCRIPTION
Usecase: I'm generating commands based on a JSON schema, and I want to prevent name conflicts between the defined arguments and actual properties on the command implementation. For options there's no problem because the name the property has on the prototype isn't used at all in the usage text, but for positionals this yields

```
$ pt g @scope/package:schematic [--project-name #0] [--skip-install] [--parent-ts-config #0] [prop_--name]
```

I've prefixed positonals with `prop_--` to prevent any name clash.
The options are prefixed with `prop_` so `--project-name` maps to `prop_projectName`, but that isn't visible here.

With this change the usage statement could become

```
$ pt g @scope/package:schematic [--project-name #0] [--skip-install] [--parent-ts-config #0] [name]
```

which is a lot more userfriendly