### PR TITLE
feat: allow to provide custom error handler

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -219,7 +219,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
     }
 
     async run(input: Command<Context> | string[], context: Context) {
-        let command;
+        let command: Command<Context>;
 
         if (!Array.isArray(input)) {
             command = input;
@@ -252,7 +252,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
 
         let exitCode;
         try {
-            exitCode = await command.validateAndExecute();
+            exitCode = await command.validateAndExecute().catch(error => command.catch(error).then(() => 0));
         } catch (error) {
             context.stdout.write(this.error(error, {command}));
             return 1;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -349,7 +349,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
             }
         }
 
-        const exitCode = await this.execute().catch(error => this.catch(error));
+        const exitCode = await this.execute();
         if (typeof exitCode !== `undefined`) {
             return exitCode;
         } else {

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -326,6 +326,15 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
      */
     abstract async execute(): Promise<number | void>;
 
+    /**
+     * Standard error handler which will simply rethrow the error. Can be used to add custom logic to handle errors
+     * from the command or simply return the parent class error handling.
+     * @param error
+     */
+    async catch(error: any): Promise<void> {
+        throw error;
+    }
+
     async validateAndExecute(): Promise<number> {
         const commandClass = this.constructor as CommandClass<Context>;
         const schema = commandClass.schema;
@@ -340,7 +349,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
             }
         }
 
-        const exitCode = await this.execute();
+        const exitCode = await this.execute().catch(error => this.catch(error));
         if (typeof exitCode !== `undefined`) {
             return exitCode;
         } else {

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -372,4 +372,49 @@ describe(`Advanced`, () => {
             ];
         }, [])).to.be.rejectedWith(`non-error rejection`);
     });
+
+    it(`should use default error handler when no custom logic is registered`, async () => {
+        await expect(runCli(() => {
+            class CommandA extends Command {
+                async execute() {throw new Error(`default error`)}
+            }
+
+            return [
+                CommandA,
+            ];
+        }, [])).to.be.rejectedWith(`default error`);
+    });
+
+    it(`should allow to override error handler`, async () => {
+        let catchCalled = false;
+
+        await expect(runCli(() => {
+            class CommandA extends Command {
+                async execute() {throw new Error(`command failed`)}
+                async catch(error: Error) {
+                    catchCalled = true;
+                    throw error;
+                }
+            }
+
+            return [
+                CommandA,
+            ];
+        }, [])).to.be.rejectedWith(`command failed`);
+
+        expect(catchCalled).to.be.true;
+    });
+
+    it(`should not throw if custom error handler swallows error`, async () => {
+        await expect(runCli(() => {
+            class CommandA extends Command {
+                async execute() {throw new Error(`command failed`)}
+                async catch() {}
+            }
+
+            return [
+                CommandA,
+            ];
+        }, [])).to.eventually.equal(``);
+    });
 });


### PR DESCRIPTION
This PR adds the ability to provide a custom error handler via an `async catch()` method on the `Command`.

Example:

```ts
class MyCommand extends Command {
  async execute() { 
    throw new Error(`command failed`)
  }

  async catch(error: Error) {
    // handle error
    // you could then re-throw the error, call `super.catch(error)` or simply gracefully ignore the error
  }
}
```