### PR TITLE
fix(docs): fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Specifies that the command accepts a set of string arguments.
 
 ```ts
 class RunCommand extends Command {
-    @Command.Boolean('--arg')
+    @Command.Array('--arg')
     public values: string[];
     // ...
 }


### PR DESCRIPTION
The example code of `Command.Array` was wrong so I fixed it.