### PR TITLE
feat: custom arity for Command.String and Command.Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,7 @@ Note that in this case the option variables never get assigned default values, s
 
 ## Decorators
 
-### Positional Decorators
-
-Positional decorators have 2 unique common traits:
-1) The arguments can't start with `-`, unless proxied or part of the command path.
-2) The order of the arguments matters, positionals being consumed from left to right, in the order they have been registered.
+The `optionNames` parameters all indicate that you should put there a comma-separated list of option names (along with their leading `-`). For example, `-v,--verbose` is a valid parameter.
 
 #### `@Command.Path(segment1?: string, segment2?: string, ...)`
 
@@ -123,7 +119,7 @@ Specifies through which CLI path should trigger the command.
 class RunCommand extends Command {
     @Command.Path(segment1, segment2, segment3)
     async execute() {
-    // ...
+        // ...
     }
 }
 ```
@@ -141,7 +137,7 @@ class YarnCommand extends Command {
     @Command.Path(`install`)
     @Command.Path()
     async execute() {
-    // ...
+        // ...
     }
 }
 ```
@@ -154,9 +150,13 @@ yarn install
 yarn
 ```
 
-#### `@Command.String({required?: boolean})`
+#### `@Command.String(opts: {...})`
 
-Specifies that the command accepts a positional argument. By default it will be required, but this can be toggled off.
+| Option | type | Description |
+| --- | --- | --- |
+| `required` | `boolean` | Whether the positional argument is required or not |
+
+Specifies that the command accepts a positional argument. By default it will be required, but this can be toggled off using `required`.
 
 ```ts
 class RunCommand extends Command {
@@ -199,46 +199,42 @@ run
 # invalid
 ```
 
-### Option Decorators
+#### `@Command.String(optionNames: string, opts: {...})`
 
-Option decorators have 2 unique common traits:
-1) The option names always start with `-`.
-2) The order of options doesn't matter.
+| Option | type | Description |
+| --- | --- | --- |
+| `arity` | `number` | Number of arguments for the option |
+| `description` | `string`| Short description for the help message |
+| `hidden` | `boolean` | Hide the option from any usage list |
+| `tolerateBoolean` | `boolean` | Accept the option even if no argument is provided |
 
-**Note:** Options can be passed before, between, and after positionals, including even before the path itself (`yarn --interactive add lodash`).
-
-The `optionNames` parameters all indicate that you should put there a comma-separated list of option names (along with their leading `-`). For example, `-v,--verbose` is a valid parameter.
-
-#### `@Command.String(optionNames: string, {tolerateBoolean?: boolean, description?: string})`
-
-Specifies that the command accepts an option that takes an argument. Arguments can be specified on the command line using either `--foo=ARG` or `--foo ARG`.
+Specifies that the command accepts an option that takes arguments (by default one, unless overriden via `arity`). Arguments can be specified on the command line using either `--foo=ARG` or `--foo ARG`.
 
 ```ts
 class RunCommand extends Command {
-    @Command.String('--foo,-f')
-    public bar?: string;
+    @Command.String(`-a,--arg`)
+    arg?: string;
 }
 ```
 
 Generates:
 
 ```bash
-run --foo <ARG>
-run --foo=<ARG>
-run -f <ARG>
-run -f=<ARG>
-# => bar = ARG
+run --arg <ARG>
+run --arg=<ARG>
+run -a <ARG>
+run -a=<ARG>
+# => arg = ARG
 ```
 
 Be careful, by default, options that accept an argument must receive one on the CLI (ie `--foo --bar` wouldn't be valid if `--foo` accepts an argument).
 
-This behaviour can be toggled off if the `tolerateBoolean` option is set. In this case, the option will act like a boolean flag if it doesn't have a value. Note that with this option on, arguments values can only be specified using the `--foo=ARG` syntax.
+This behaviour can be toggled off if the `tolerateBoolean` option is set. In this case, the option will act like a boolean flag if it doesn't have a value. Note that with this option on, arguments values can only be specified using the `--foo=ARG` syntax, which makes this option incompatible with arities higher than one.
 
 ```ts
 class RunCommand extends Command {
     @Command.String(`--inspect`, {tolerateBoolean: true})
     public debug: boolean | string = false;
-    // ...
 }
 ```
 
@@ -249,32 +245,41 @@ run --inspect
 # => debug = true
 
 run --inspect=1234
-# debug = "1234"
+# => debug = "1234"
 
 run --inspect 1234
 # invalid
 ```
 
-#### `@Command.Boolean(optionNames: string, {description?: string})`
+#### `@Command.Boolean(optionNames: string, opts: {...})`
+
+| Option | type | Description |
+| --- | --- | --- |
+| `description` | `string`| Short description for the help message |
+| `hidden` | `boolean` | Hide the option from any usage list |
 
 Specifies that the command accepts a boolean flag as an option.
 
 ```ts
 class RunCommand extends Command {
-    @Command.Boolean('--foo')
-    public bar: boolean;
-    // ...
+    @Command.Boolean(`--flag`)
+    public flag: boolean;
 }
 ```
 
 Generates:
 
 ```bash
-run --foo
-# => bar = true
+run --flag
+# => flag = true
 ```
 
-#### `@Command.Counter(optionNames: string, {description?: string})`
+#### `@Command.Counter(optionNames: string, {...})`
+
+| Option | type | Description |
+| --- | --- | --- |
+| `description` | `string`| Short description for the help message |
+| `hidden` | `boolean` | Hide the option from any usage list |
 
 Specifies that the command accepts a boolean flag as an option, which will increment a counter for each detected occurrence. Each time the argument is negated, the counter will be reset to `0`. The counter won't be set unless the option is found, so you must remember to set it to an appropriate default value.
 
@@ -282,7 +287,6 @@ Specifies that the command accepts a boolean flag as an option, which will incre
 class RunCommand extends Command {
     @Command.Counter('-v,--verbose')
     public verbose: number = 0;
-    // ...
 }
 ```
 
@@ -305,47 +309,23 @@ run --verbose -v --verbose -v --no-verbose
 # => verbose = 0
 ```
 
-#### `@Command.Tuple(optionNames: string, {length: number, description?: string})`
+#### `@Command.Array(optionNames: string, opts: {...})`
 
-Specifies that the command accepts an option that takes a fixed number of arguments. Arguments can only be specified on the command line using `--foo ARG`, not `--foo=ARG`.
+| Option | type | Description |
+| --- | --- | --- |
+| `arity` | `number` | Number of arguments for the option |
+| `description` | `string`| Short description for the help message |
+| `hidden` | `boolean` | Hide the option from any usage list |
 
-```ts
-class RunCommand extends Command {
-    @Command.Tuple('--arg', {length: 3})
-    public values: [string, string, string];
-    // ...
-}
-```
-
-Generates:
-
-```bash
-run --arg value1 value2 value3
-# => values = [value1, value2, value3]
-
-run --arg value1 value2
-# => Error - too few arguments
-
-run --arg value1 value2 value3 value4
-# => Error - too many arguments
-```
-
-### Modifier Decorators
-
-Modifier decorators augment the behavior of other decorators. Because of this, they should always be called *before* the decorators they modify. In terms of the decorator evaluation order, this means that they should be *below* the decorators they modify.
-
-#### `@Command.Array()`
-
-An *option* modifier that causes the attached option decorator to push its arguments into an array instead of overriding its previous arguments.
-
-Supported option decorators: `Command.String`, `Command.Boolean`, and `Command.Tuple`.
+Specifies that the command accepts a set of string arguments. The `arity` parameter defines how many values need to be accepted for each item.
 
 ```ts
 class RunCommand extends Command {
-    @Command.String('--arg')
-    @Command.Array()
-    public values: string[];
-    // ...
+    @Command.Array('--arg')
+    public args: string[];
+
+    @Command.Array('--point', {arity: 3})
+    public points: [string, string, string][];
 }
 ```
 
@@ -353,7 +333,10 @@ Generates:
 
 ```bash
 run --arg value1 --arg value2
-# => values = [value1, value2]
+# => args = [value1, value2]
+
+run --point x y z --point a b c
+# => points = [['x', 'y', 'z'], ['a', 'b', 'c']]
 ```
 
 ## Command Help Pages

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `optionNames` parameters all indicate that you should put there a comma-sepa
 
 #### `@Command.Path(segment1?: string, segment2?: string, ...)`
 
-Specifies through which CLI path should trigger the command. 
+Specifies through which CLI path should trigger the command.
 
 **This decorator can only be set on the `execute` function itself**, as it isn't linked to specific options.
 
@@ -278,6 +278,31 @@ Generates:
 ```bash
 run --arg value1 --arg value2
 # => values = [value1, value2]
+```
+
+#### `@Command.Tuple(optionNames: string, {length: number})`
+
+Specifies that the command accepts an option that takes a fixed number of arguments. Arguments can only be specified on the command line using `--foo ARG`, not `--foo=ARG`.
+
+```ts
+class RunCommand extends Command {
+    @Command.Tuple('--arg', {length: 3})
+    public values: [string, string, string];
+    // ...
+}
+```
+
+Generates:
+
+```bash
+run --arg value1 value2 value3
+# => values = [value1, value2, value3]
+
+run --arg value1 value2
+# => Error - too few arguments
+
+run --arg value1 value2 value3 value4
+# => Error - too many arguments
 ```
 
 ## Command Help Pages

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ run --verbose -v --verbose -v --no-verbose
 # => verbose = 0
 ```
 
-#### `@Command.Tuple(optionNames: string, {length: number})`
+#### `@Command.Tuple(optionNames: string, {length: number, description?: string})`
 
 Specifies that the command accepts an option that takes a fixed number of arguments. Arguments can only be specified on the command line using `--foo ARG`, not `--foo=ARG`.
 

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -209,11 +209,9 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
                 const command = new commandClass();
                 command.path = state.path;
 
-                const {transformers, cleanups} = commandClass.resolveMeta(commandClass.prototype);
+                const {transformers} = commandClass.resolveMeta(commandClass.prototype);
                 for (const transformer of transformers)
                     transformer(state, command);
-                for (const cleanup of cleanups)
-                    cleanup(command);
 
                 return command;
             } break;

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -209,9 +209,11 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
                 const command = new commandClass();
                 command.path = state.path;
 
-                const {transformers} = commandClass.resolveMeta(commandClass.prototype);
+                const {transformers, cleanups} = commandClass.resolveMeta(commandClass.prototype);
                 for (const transformer of transformers)
                     transformer(state, command);
+                for (const cleanup of cleanups)
+                    cleanup(command);
 
                 return command;
             } break;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -255,7 +255,13 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
     /**
      * Register a listener that looks for an option and its followup arguments. When Clipanion detects that these arguments are present, the values will be pushed into the tuple represented in the property.
      */
-    static Tuple(descriptor: string, {length, hidden = false}: {length: number, hidden?: boolean}) {
+    static Tuple(descriptor: string, {length, hidden = false}: {
+        /**
+         * The constant length of the tuple - the number of arguments the option accepts.
+         */
+        length: number,
+        hidden?: boolean
+    }) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             const optNames = descriptor.split(`,`);
 

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -281,18 +281,19 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
     /**
      * Register a listener that looks for an option and its followup arguments. When Clipanion detects that these arguments are present, the values will be pushed into the tuple represented in the property.
      */
-    static Tuple(descriptor: string, {length, hidden = false}: {
+    static Tuple(descriptor: string, {length, hidden = false, description}: {
         /**
          * The constant length of the tuple - the number of arguments the option accepts.
          */
-        length: number,
-        hidden?: boolean
+        length: number;
+        hidden?: boolean;
+        description?: string;
     }) {
         return <Context extends BaseContext>(prototype: Command<Context>, propertyName: string) => {
             const optNames = descriptor.split(`,`);
 
             this.registerDefinition(prototype, command => {
-                command.addOption({names: optNames, arity: length, hidden, allowBinding: false});
+                command.addOption({names: optNames, arity: length, hidden, allowBinding: false, description});
             });
 
             this.registerTransformer(prototype, (state, command) => {

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -371,7 +371,8 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
 
                 this.registerCleanup(prototype, (command) => {
                     // We cleanup the getter and setter
-                    // after all transformers have run.
+                    // after all transformers have run and
+                    // replace it with the array of values.
                     Object.defineProperty(command, propertyName, {
                         configurable: true,
                         enumerable: true,

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -621,19 +621,6 @@ describe(`Advanced`, () => {
         }
     });
 
-    it(`should extract string arrays from complex options (legacy style)`, async () => {
-        class IncludeCommand extends Command {
-            @Command.Array(`--include`)
-            include: string[] = [];
-
-            async execute() {}
-        }
-
-        const cli = Cli.from([IncludeCommand]);
-
-        expect(cli.process([`--include`, `foo`, `--include`, `bar`])).to.deep.contain({include: [`foo`, `bar`]});
-    });
-
     it(`should extract string arrays from complex options`, async () => {
         class IncludeCommand extends Command {
             @Command.Array(`--include`)

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -576,4 +576,28 @@ describe(`Advanced`, () => {
             Cli.from([PointCommand])
         }).to.throw(`The arity must be positive, got -1`);
     });
+
+    it(`should throw acceptable errors when not enough arguments are passed to a tuple`, async () => {
+        class PointCommand extends Command {
+            @Command.Tuple(`--point`, {length: 3})
+            point!: [x: string, y: string, z: string];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([PointCommand]);
+
+        const error = `Not enough arguments to option --point.`;
+
+        for (const args of [
+            [`--point`],
+            [`--point`, `1`],
+            [`--point`, `1`, `2`],
+            [`--point`, `1`, `--foo`],
+            [`--point`, `1`, `-abcd`],
+            [`--point`, `1`, `2`, `--bar=baz`],
+        ]) {
+            expect(() => cli.process(args)).to.throw(error);
+        }
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -625,4 +625,75 @@ describe(`Advanced`, () => {
             expect(() => cli.process(args)).to.throw(error);
         }
     });
+
+    it(`should extract string arrays from complex options (legacy style)`, async () => {
+        class IncludeCommand extends Command {
+            @Command.Array(`--include`)
+            include: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([IncludeCommand]);
+
+        expect(cli.process([`--include`, `foo`, `--include`, `bar`])).to.deep.contain({include: [`foo`, `bar`]});
+    });
+
+    it(`should extract string arrays from complex options`, async () => {
+        class IncludeCommand extends Command {
+            @Command.String(`--include`)
+            @Command.Array()
+            include: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([IncludeCommand]);
+
+        expect(cli.process([])).to.deep.contain({include: []});
+        expect(cli.process([`--include`, `foo`])).to.deep.contain({include: [`foo`]});
+        expect(cli.process([`--include`, `foo`, `--include`, `bar`])).to.deep.contain({include: [`foo`, `bar`]});
+    });
+
+    it(`should extract boolean arrays from complex options`, async () => {
+        class IncludeCommand extends Command {
+            @Command.Boolean(`--include`)
+            @Command.Array()
+            include: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([IncludeCommand]);
+
+        expect(cli.process([])).to.deep.contain({include: []});
+        expect(cli.process([`--include`])).to.deep.contain({include: [true]});
+        expect(cli.process([`--include`,`--include`])).to.deep.contain({include: [true, true]});
+    });
+
+    it(`should extract tuple arrays from complex options`, async () => {
+        class IncludeCommand extends Command {
+            @Command.Tuple(`--position`, {length: 3})
+            @Command.Array()
+            position: Array<[string, string, string]> = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([IncludeCommand]);
+
+        expect(cli.process([])).to.deep.contain({position: []});
+        expect(cli.process(
+            [`--position`, `1`, `2`, `3`]
+        )).to.deep.contain({position: [[`1`, `2`, `3`]]});
+        expect(cli.process([
+            `--position`, `1`, `2`, `3`,
+            `--position`, `4`, `5`, `6`,
+        ])).to.deep.contain({position: [[`1`, `2`, `3`], [`4`, `5`, `6`]]});
+        expect(cli.process([
+            `--position`, `1`, `2`, `3`,
+            `--position`, `4`, `5`, `6`,
+            `--position`, `7`, `8`, `9`,
+        ])).to.deep.contain({position: [[`1`, `2`, `3`], [`4`, `5`, `6`], [`7`, `8`, `9`]]});
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -524,9 +524,9 @@ describe(`Advanced`, () => {
         expect(cli.usage(CommandA, {detailed: true})).to.equal(`\u001b[1m$ \u001b[22m... greet [--message #0]\n\n\u001b[1mOptions:\u001b[22m\n\n  --verbose      Log output\n  --output #0    The output directory\n`);
     });
 
-    it(`should extract tuples from complex options`, async () => {
+    it(`should support tuples`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: 3})
+            @Command.String(`--point`, {arity: 3})
             point!: [x: string, y: string, z: string];
 
             async execute() {}
@@ -537,36 +537,9 @@ describe(`Advanced`, () => {
         expect(cli.process([`--point`, `1`, `2`, `3`])).to.deep.contain({point: [`1`, `2`, `3`]});
     });
 
-    it(`shouldn't allow binding tuple elements`, async () => {
-        class Arity0Command extends Command {
-            @Command.Tuple(`--thing`, {length: 0})
-            thing!: [boolean];
-
-            @Command.Path('arity0')
-            async execute() {}
-        }
-
-        class Arity1Command extends Command {
-            @Command.Tuple(`--thing`, {length: 1})
-            thing!: [string];
-
-            @Command.Path('arity1')
-            async execute() {}
-        }
-
-        const cli = Cli.from([Arity0Command, Arity1Command]);
-
-        expect(() => {
-            cli.process([`arity0`, `--thing=something`])
-        }).to.throw(`Invalid option name ("--thing=something")`);
-        expect(() => {
-            cli.process([`arity1`, `--thing=something`])
-        }).to.throw(`Invalid option name ("--thing=something")`);
-    });
-
     it(`should extract tuples from complex options surrounded by rest arguments`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: 3})
+            @Command.String(`--point`, {arity: 3})
             point!: [x: string, y: string, z: string];
 
             @Command.Rest()
@@ -587,7 +560,7 @@ describe(`Advanced`, () => {
 
     it(`should throw acceptable errors when tuple length is not finite`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: Infinity})
+            @Command.String(`--point`, {arity: Infinity})
             point!: [x: string, y: string, z: string];
 
             async execute() {}
@@ -600,7 +573,7 @@ describe(`Advanced`, () => {
 
     it(`should throw acceptable errors when tuple length is not an integer`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: 1.5})
+            @Command.String(`--point`, {arity: 1.5})
             point!: [x: string, y: string, z: string];
 
             async execute() {}
@@ -613,7 +586,7 @@ describe(`Advanced`, () => {
 
     it(`should throw acceptable errors when tuple length is not positive`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: -1})
+            @Command.String(`--point`, {arity: -1})
             point!: [x: string, y: string, z: string];
 
             async execute() {}
@@ -626,7 +599,7 @@ describe(`Advanced`, () => {
 
     it(`should throw acceptable errors when not enough arguments are passed to a tuple`, async () => {
         class PointCommand extends Command {
-            @Command.Tuple(`--point`, {length: 3})
+            @Command.String(`--point`, {arity: 3})
             point!: [x: string, y: string, z: string];
 
             async execute() {}
@@ -663,8 +636,7 @@ describe(`Advanced`, () => {
 
     it(`should extract string arrays from complex options`, async () => {
         class IncludeCommand extends Command {
-            @Command.String(`--include`)
-            @Command.Array()
+            @Command.Array(`--include`)
             include: string[] = [];
 
             async execute() {}
@@ -677,26 +649,9 @@ describe(`Advanced`, () => {
         expect(cli.process([`--include`, `foo`, `--include`, `bar`])).to.deep.contain({include: [`foo`, `bar`]});
     });
 
-    it(`should extract boolean arrays from complex options`, async () => {
-        class IncludeCommand extends Command {
-            @Command.Boolean(`--include`)
-            @Command.Array()
-            include: string[] = [];
-
-            async execute() {}
-        }
-
-        const cli = Cli.from([IncludeCommand]);
-
-        expect(cli.process([])).to.deep.contain({include: []});
-        expect(cli.process([`--include`])).to.deep.contain({include: [true]});
-        expect(cli.process([`--include`,`--include`])).to.deep.contain({include: [true, true]});
-    });
-
     it(`should extract tuple arrays from complex options`, async () => {
         class IncludeCommand extends Command {
-            @Command.Tuple(`--position`, {length: 3})
-            @Command.Array()
+            @Command.Array(`--position`, {arity: 3})
             position: Array<[string, string, string]> = [];
 
             async execute() {}


### PR DESCRIPTION
Edit: The original description isn't accurate anymore, see https://github.com/arcanis/clipanion/pull/40#issuecomment-694146387 for an updated description.

~~Just a fun experiment I've played with during the past few hours: `Command.Tuple` - options accepting a fixed number of arguments.~~

~~This PR introduces a new `Command.Tuple(optNames: string, {length: number})` decorator, which allows for fixed arity options (other than `0` or `1`). This enables use cases such as `filter-players Player1 Player2 Player3 --by-position 1 2 3`.~~

~~It works by modifying `commandBuilder.registerOptions` to make it work correctly with arities higher than 1 (the same code is used even when the arity is `1`).~~

~~I've also added tests and updated the documentation.~~

~~My only concern about this that I haven't been able to find a solution for: A way to make it also work with the `Command.Array` decorator (`bin --position 1 2 3 --position 4 5 6`). I was initially thinking about overloading both the `Command.String` and `Command.Array` decorator to allow specifying a custom arity, but `Command.String` is already overloaded enough and it also wouldn't make sense for a decorator called `Command.String` to return a tuple. That's why I've decided on `Command.Tuple` for single occurrences, but I don't know what's the best way to compose both `Command.Array` and `Command.Tuple`. I'm really curious about what your ideas are on this.~~