### PR TITLE
feat: Command.Counter - boolean option counter ("run -vvv")

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `optionNames` parameters all indicate that you should put there a comma-sepa
 
 #### `@Command.Path(segment1?: string, segment2?: string, ...)`
 
-Specifies through which CLI path should trigger the command. 
+Specifies through which CLI path should trigger the command.
 
 **This decorator can only be set on the `execute` function itself**, as it isn't linked to specific options.
 
@@ -259,6 +259,37 @@ Generates:
 ```bash
 run --foo
 # => bar = true
+```
+
+#### `@Command.Counter(optionNames: string)`
+
+Specifies that the command accepts a boolean flag as an option, which will increment a counter for each detected occurrence. Each time the argument is negated, the counter will be reset to `0`. The counter won't be set unless the option is found, so you must remember to set it to an appropriate default value.
+
+```ts
+class RunCommand extends Command {
+    @Command.Counter('-v,--verbose')
+    public verbose: number = 0;
+    // ...
+}
+```
+
+Generates:
+
+```bash
+run
+# => verbose = 0
+
+run -v
+# => verbose = 1
+
+run -vv
+# => verbose = 2
+
+run --verbose -v --verbose -v
+# => verbose = 4
+
+run --verbose -v --verbose -v --no-verbose
+# => verbose = 0
 ```
 
 #### `@Command.Array(optionNames: string)`

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -202,8 +202,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                         if (!value) {
                             // @ts-ignore: The property is meant to have been defined by the child class
                             command[propertyName] = 0;
-                        }
-                        else {
+                        } else {
                             // @ts-ignore: The property is meant to have been defined by the child class
                             command[propertyName]++;
                         }

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -476,4 +476,29 @@ describe(`Advanced`, () => {
 
         expect(Object.values(calls).every(Boolean)).to.be.true;
     });
+
+    it(`should extract counter options from complex options`, async () => {
+        class CommandA extends Command {
+            @Command.Counter(`-v,--verbose`)
+            verbose: number = 0;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CommandA]);
+
+        expect(cli.process([])).to.contain({verbose: 0});
+        expect(cli.process([`-v`])).to.contain({verbose: 1});
+        expect(cli.process([`-vv`])).to.contain({verbose: 2});
+        expect(cli.process([`-vvv`])).to.contain({verbose: 3});
+        expect(cli.process([`-vvvv`])).to.contain({verbose: 4});
+
+        expect(cli.process([`-v`, `-v`])).to.contain({verbose: 2});
+        expect(cli.process([`--verbose`, `--verbose`])).to.contain({verbose: 2});
+        expect(cli.process([`-v`, `--verbose`])).to.contain({verbose: 2});
+        expect(cli.process([`--verbose`, `-v`])).to.contain({verbose: 2});
+
+        expect(cli.process([`-vvvv`, `--no-verbose`])).to.contain({verbose: 0});
+        expect(cli.process([`--no-verbose`, `-vvvv`])).to.contain({verbose: 4});
+    });
 });


### PR DESCRIPTION
Yet another fun experiment - `Command.Counter` - a boolean option counter.

Each time a boolean option is detected, the counter will be incremented. Each time the boolean option is negated, the counter will be reset to `0`. The counter isn't initially set to `0`, the user has to set a default instead.

This enables use cases such as `yarn install -vvv` (just an example, I'm not planning to implement it in Yarn).

Just like the documentation says, all combinations are allowed:

```bash
run
# => verbose = 0
run -v
# => verbose = 1
run -vv
# => verbose = 2
run --verbose -v --verbose -v
# => verbose = 4
run --verbose -v --verbose -v --no-verbose
# => verbose = 0
```

I've also updated the documentation and added tests.