### PR TITLE
fix(advanced): fix positional consumption by transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ run
 # => values = []
 ```
 
-**Note:** Rest arguments are strictly positional. All options found between rest arguments will be consumed as options of the `Command` instance. For proxying, `Command.Proxy` has to be used instead.
+**Note:** Rest arguments are strictly positionals. All options found between rest arguments will be consumed as options of the `Command` instance. For proxying, `Command.Proxy` has to be used instead.
 
 **Note:** Rest arguments can be surrounded by other *finite* *non-optional* positionals such as `Command.String({required: true})`.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,39 @@ run dest
 # => Error - Not enough positional arguments.
 ```
 
+#### `@Command.Proxy({required?: number})`
+
+Specifies that the command accepts an infinite set of positional arguments that will not be consumed by the options of the `Command` instance. Used to proxy arguments to another command. By default, no arguments are required, but this can be changed by setting the `required` option.
+
+```ts
+class RunCommand extends Command {
+    @Command.Proxy()
+    public args: string[];
+    // ...
+}
+```
+
+Generates:
+
+```bash
+run value1 value2
+# => values = [value1, value2]
+
+run value1 --foo
+# => values = [value1, --foo]
+
+run --bar=baz
+# => values = [--bar=baz]
+```
+
+**Note:** Proxying can only happen once per command. Once triggered, a command can't get out of "proxy mode", all remaining arguments being proxied into a list. "Proxy mode" can be triggered in the following ways:
+
+- By passing a positional or an option that doesn't have any listeners attached to it. This happens when the listeners don't exist in the first place.
+
+- By passing a positional that doesn't have any *remaining* listeners attached to it. This happens when the listeners have already consumed a positional.
+
+- By passing the `--` separator before an option that has a listener attached to it. This will cause Clipanion to activate "proxy mode" for all arguments after the separator, *without* proxying the separator itself. In all other cases, the separator *will* be proxied and *not* consumed by Clipanion.
+
 ## Command Help Pages
 
 Clipanion automatically adds support for the `-h` option to all the commands that you define. The information printed will come from the `usage` property attached to the class. For example, the following command:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The `optionNames` parameters all indicate that you should put there a comma-sepa
 
 #### `@Command.Path(segment1?: string, segment2?: string, ...)`
 
-Specifies through which CLI path should trigger the command. 
+Specifies through which CLI path should trigger the command.
 
 **This decorator can only be set on the `execute` function itself**, as it isn't linked to specific options.
 
@@ -278,6 +278,77 @@ Generates:
 ```bash
 run --arg value1 --arg value2
 # => values = [value1, value2]
+```
+
+#### `@Command.Rest({required?: number})`
+
+Specifies that the command accepts a set of positional arguments. By default, no arguments are required, but this can be changed by setting the `required` option.
+
+```ts
+class RunCommand extends Command {
+    @Command.Rest()
+    public values: string[];
+    // ...
+}
+```
+
+Generates:
+
+```bash
+run value1 value2
+# => values = [value1, value2]
+
+run value1
+# => values = [value1]
+
+run
+# => values = []
+```
+
+**Note:** Rest arguments are strictly positional. All options found between rest arguments will be consumed as options of the `Command` instance. For proxying, `Command.Proxy` has to be used instead.
+
+**Note:** Rest arguments can be surrounded by other *finite* *non-optional* positionals such as `Command.String({required: true})`.
+
+**Advanced Example:**
+
+```ts
+class CopyCommand extends Command {
+    @Command.Rest({required: 1})
+    sources: string[] = [];
+
+    @Command.String()
+    destination!: string;
+
+    @Command.Boolean(`-f,--force`)
+    force: boolean = false;
+
+    @Command.String(`--reflink`, {tolerateBoolean: true})
+    reflink: string | boolean = false;
+
+    // ...
+}
+```
+
+Generates:
+
+```bash
+run src dest
+# => sources = [src]; destination = dest
+
+run src1 src2 dest
+# => sources = [src1, src2]; destination = dest
+
+run src1 --force src2 dest
+# => sources = [src1, src2]; destination = dest; force = true
+
+run src1 src2 --reflink=always dest
+# => sources = [src1, src2]; destination = dest; reflink = always
+
+run src
+# => Error - Not enough positional arguments.
+
+run dest
+# => Error - Not enough positional arguments.
 ```
 
 ## Command Help Pages

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -206,12 +206,18 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
             default: {
                 const {commandClass} = contexts[state.selectedIndex!];
 
+                const index = this.registrations.get(commandClass);
+                if (typeof index === `undefined`)
+                    throw new Error(`Assertion failed: Expected the command class to have been registered.`);
+
+                const commandBuilder = this.builder.getBuilderByIndex(index);
+
                 const command = new commandClass();
                 command.path = state.path;
 
                 const {transformers} = commandClass.resolveMeta(commandClass.prototype);
                 for (const transformer of transformers)
-                    transformer(state, command);
+                    transformer(state, command, commandBuilder);
 
                 return command;
             } break;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -317,7 +317,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                     if (!isNoLimits && !isLeading)
                         continue;
 
-                        // We mark this positional for removal
+                    // We mark this positional for removal
                     positionalsToRemove.push(i);
 
                     // We insert its value at the end of the array property.

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -213,8 +213,10 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                     }
                 });
             } else {
+                const {name = propertyName, required = true} = descriptor;
+
                 this.registerDefinition(prototype, command => {
-                    command.addPositional({name: descriptor.name ?? propertyName, required: descriptor.required !== false});
+                    command.addPositional({name, required});
                 });
 
                 this.registerTransformer(prototype, (state, command) => {
@@ -222,6 +224,16 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
                         // We skip NoLimits extras. We only care about
                         // required and optional finite positionals.
                         if (state.positionals[i].extra === NoLimits)
+                            continue;
+
+                        // We skip optional positionals when we only
+                        // care about required positionals.
+                        if (required && state.positionals[i].extra === true)
+                            continue;
+
+                        // We skip required positionals when we only
+                        // care about optional positionals.
+                        if (!required && state.positionals[i].extra === false)
                             continue;
 
                         // We remove the positional from the list

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -643,10 +643,10 @@ export class CommandBuilder<Context> {
     public readonly cliIndex: number;
     public readonly cliOpts: Readonly<CliOptions>;
 
-    private readonly allOptionNames: string[] = [];
-    private readonly arity: ArityDefinition = {leading: [], trailing: [], extra: [], proxy: false};
-    private readonly options: OptDefinition[] = [];
-    private readonly paths: string[][] = [];
+    public readonly allOptionNames: string[] = [];
+    public readonly arity: ArityDefinition = {leading: [], trailing: [], extra: [], proxy: false};
+    public readonly options: OptDefinition[] = [];
+    public readonly paths: string[][] = [];
 
     private context?: Context;
 

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -28,7 +28,7 @@ export type RunState = {
     ignoreOptions: boolean;
     options: {name: string, value: any}[];
     path: string[];
-    positionals: {value: string, extra: boolean}[];
+    positionals: {value: string, extra: boolean | typeof NoLimits}[];
     remainder: string | null;
     selectedIndex: number | null;
 };
@@ -587,6 +587,9 @@ export const reducers = {
     pushExtra: (state: RunState, segment: string) => {
         return {...state, positionals: state.positionals.concat({value: segment, extra: true})}
     },
+    pushExtraNoLimits: (state: RunState, segment: string) => {
+        return {...state, positionals: state.positionals.concat({value: segment, extra: NoLimits})}
+    },
     pushTrue: (state: RunState, segment: string, name: string = segment) => {
         return {...state, options: state.options.concat({name: segment, value: true})};
     },
@@ -806,8 +809,8 @@ export class CommandBuilder<Context> {
                     if (!this.arity.proxy)
                         this.registerOptions(machine, extraNode);
 
-                    registerDynamic(machine, lastLeadingNode, positionalArgument, extraNode, `pushExtra`);
-                    registerDynamic(machine, extraNode, positionalArgument, extraNode, `pushExtra`);
+                    registerDynamic(machine, lastLeadingNode, positionalArgument, extraNode, `pushExtraNoLimits`);
+                    registerDynamic(machine, extraNode, positionalArgument, extraNode, `pushExtraNoLimits`);
                     registerShortcut(machine, extraNode, extraShortcutNode);
                 } else {
                     for (let t = 0; t < this.arity.extra.length; ++t) {

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -645,4 +645,36 @@ describe(`Advanced`, () => {
 
         expect(() => cli.process([`dest`])).to.throw();
     });
+
+    it(`should support proxies`, async () => {
+        class CopyCommand extends Command {
+            @Command.Proxy()
+            args: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(cli.process([])).to.deep.contain({args: []});
+        expect(cli.process([`foo`])).to.deep.contain({args: [`foo`]});
+        expect(cli.process([`foo`, `--bar`])).to.deep.contain({args: [`foo`, `--bar`]});
+        expect(cli.process([`foo`, `--bar`, `--baz=1`])).to.deep.contain({args: [`foo`, `--bar`, `--baz=1`]});
+    });
+
+    it(`should support proxies with a minimum required length`, async () => {
+        class CopyCommand extends Command {
+            @Command.Proxy({required: 1})
+            args: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(() => cli.process([])).to.throw();
+        expect(cli.process([`foo`])).to.deep.contain({args: [`foo`]});
+        expect(cli.process([`foo`, `--bar`])).to.deep.contain({args: [`foo`, `--bar`]});
+        expect(cli.process([`foo`, `--bar`, `--baz=1`])).to.deep.contain({args: [`foo`, `--bar`, `--baz=1`]});
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -536,4 +536,48 @@ describe(`Advanced`, () => {
             destination: 'dest',
         });
     });
+
+    it(`should support rest arguments with a minimum required length`, async () => {
+        class CopyCommand extends Command {
+            @Command.Rest({required: 1})
+            sources: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(() => cli.process([])).to.throw();
+        expect(cli.process([`src1`])).to.deep.contain({sources: [`src1`]});
+        expect(cli.process([`src1`, `src2`])).to.deep.contain({sources: [`src1`, `src2`]});
+        expect(cli.process([`src1`, `src2`, `src3`])).to.deep.contain({sources: [`src1`, `src2`, `src3`]});
+    });
+
+    it(`should support required positionals after rest arguments with a minimum required length`, async () => {
+        class CopyCommand extends Command {
+            @Command.Rest({required: 1})
+            sources: string[] = [];
+
+            @Command.String()
+            destination!: string;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(() => cli.process([])).to.throw();
+        expect(() => cli.process([`src`])).to.throw();
+        expect(() => cli.process([`dest`])).to.throw();
+
+        expect(cli.process([`src`, `dest`])).to.deep.contain({
+            sources: [`src`],
+            destination: 'dest',
+        });
+
+        expect(cli.process([`src1`, `src2`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+        });
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -476,4 +476,64 @@ describe(`Advanced`, () => {
 
         expect(Object.values(calls).every(Boolean)).to.be.true;
     });
+
+    it(`should support optional string positionals`, async () => {
+        class ThingCommand extends Command {
+            @Command.String({required: false})
+            thing: string | null = null;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([ThingCommand]);
+
+        expect(cli.process([])).to.contain({thing: null});
+        expect(cli.process([`hello`])).to.contain({thing: `hello`});
+    });
+
+    it(`should support optional string positionals after required string positionals`, async () => {
+        class CopyCommand extends Command {
+            @Command.String()
+            requiredThing!: string;
+
+            @Command.String({required: false})
+            optionalThing: string | null = null;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(cli.process([`hello`])).to.contain({optionalThing: null});
+        expect(cli.process([`hello`, `world`])).to.contain({optionalThing: `world`});
+    });
+
+    it(`should support required positionals after rest arguments`, async () => {
+        class CopyCommand extends Command {
+            @Command.Rest()
+            sources: string[] = [];
+
+            @Command.String()
+            destination!: string;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(cli.process([`dest`])).to.deep.contain({
+            sources: [],
+            destination: 'dest',
+        });
+
+        expect(cli.process([`src`, `dest`])).to.deep.contain({
+            sources: [`src`],
+            destination: 'dest',
+        });
+
+        expect(cli.process([`src1`, `src2`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+        });
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -580,4 +580,69 @@ describe(`Advanced`, () => {
             destination: 'dest',
         });
     });
+
+    // We have this in the README, that's why we're testing it
+    it(`should support implementing a cp-like command`, async () => {
+        class CopyCommand extends Command {
+            @Command.Rest({required: 1})
+            sources: string[] = [];
+
+            @Command.String()
+            destination!: string;
+
+            @Command.Boolean(`-f,--force`)
+            force: boolean = false;
+
+            @Command.String(`--reflink`, {tolerateBoolean: true})
+            reflink: string | boolean = false;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(cli.process([`src`, `dest`])).to.deep.contain({
+            sources: [`src`],
+            destination: 'dest',
+            force: false,
+            reflink: false,
+        });
+
+        expect(cli.process([`src1`, `src2`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+            force: false,
+            reflink: false,
+        });
+
+        expect(cli.process([`src1`, `--force`, `src2`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+            force: true,
+            reflink: false,
+        });
+
+        expect(cli.process([`src1`, `src2`, `--force`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+            force: true,
+            reflink: false,
+        });
+
+        expect(cli.process([`src1`, `src2`, `--reflink`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+            force: false,
+            reflink: true,
+        });
+
+        expect(cli.process([`src1`, `--reflink=always`, `src2`, `dest`])).to.deep.contain({
+            sources: [`src1`, `src2`],
+            destination: 'dest',
+            force: false,
+            reflink: `always`,
+        });
+
+        expect(() => cli.process([`dest`])).to.throw();
+    });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -509,7 +509,7 @@ describe(`Advanced`, () => {
 
             @Command.String('--output', {description: 'The output directory'})
             output?: string;
-        
+
             @Command.String('--message')
             message?: string;
 

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -508,6 +508,23 @@ describe(`Advanced`, () => {
         expect(cli.process([`hello`, `world`])).to.contain({optionalThing: `world`});
     });
 
+    it(`should support optional string positionals before required string positionals`, async () => {
+        class CopyCommand extends Command {
+            @Command.String({required: false})
+            optionalThing: string | null = null;
+
+            @Command.String()
+            requiredThing!: string;
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([CopyCommand]);
+
+        expect(cli.process([`hello`])).to.contain({optionalThing: null, requiredThing: `hello`});
+        expect(cli.process([`hello`, `world`])).to.contain({optionalThing: `hello`, requiredThing: `world`});
+    });
+
     it(`should support required positionals after rest arguments`, async () => {
         class CopyCommand extends Command {
             @Command.Rest()

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,6 +1,6 @@
 import {expect}                         from 'chai';
 
-import {CliBuilderCallback, CliBuilder} from '../sources/core';
+import {CliBuilderCallback, CliBuilder, NoLimits} from '../sources/core';
 
 const makeCli = (definitions: CliBuilderCallback<{}>[]) => {
     return CliBuilder.build<{}>(definitions.map(cb => {
@@ -434,9 +434,9 @@ describe(`Core`, () => {
 
         const {positionals} = cli.process([`foo`, `bar`, `baz`]);
         expect(positionals).to.deep.equal([
-            {value: `foo`, extra: true},
-            {value: `bar`, extra: true},
-            {value: `baz`, extra: true},
+            {value: `foo`, extra: NoLimits},
+            {value: `bar`, extra: NoLimits},
+            {value: `baz`, extra: NoLimits},
         ]);
     });
 
@@ -450,9 +450,9 @@ describe(`Core`, () => {
 
         const {positionals} = cli.process([`src1`, `src2`, `src3`, `dest`]);
         expect(positionals).to.deep.equal([
-            {value: `src1`, extra: true},
-            {value: `src2`, extra: true},
-            {value: `src3`, extra: true},
+            {value: `src1`, extra: NoLimits},
+            {value: `src2`, extra: NoLimits},
+            {value: `src3`, extra: NoLimits},
             {value: `dest`, extra: false},
         ]);
     });
@@ -469,9 +469,9 @@ describe(`Core`, () => {
         const {positionals} = cli.process([`foo`, `src1`, `src2`, `src3`, `dest`]);
         expect(positionals).to.deep.equal([
             {value: `foo`, extra: false},
-            {value: `src1`, extra: true},
-            {value: `src2`, extra: true},
-            {value: `src3`, extra: true},
+            {value: `src1`, extra: NoLimits},
+            {value: `src2`, extra: NoLimits},
+            {value: `src3`, extra: NoLimits},
             {value: `dest`, extra: false},
         ]);
     });
@@ -493,9 +493,9 @@ describe(`Core`, () => {
         ]);
 
         expect(positionals).to.deep.equal([
-            {value: `src1`, extra: true},
-            {value: `src2`, extra: true},
-            {value: `src3`, extra: true},
+            {value: `src1`, extra: NoLimits},
+            {value: `src2`, extra: NoLimits},
+            {value: `src3`, extra: NoLimits},
         ]);
     });
 
@@ -535,7 +535,7 @@ describe(`Core`, () => {
 
         expect(positionals).to.deep.equal([
             {value: `foo`, extra: false},
-            {value: `-x`, extra: true},
+            {value: `-x`, extra: NoLimits},
         ]);
     });
 
@@ -555,7 +555,7 @@ describe(`Core`, () => {
         ]);
 
         expect(positionals).to.deep.equal([
-            {value: `-x`, extra: true},
+            {value: `-x`, extra: NoLimits},
         ]);
     });
 
@@ -679,8 +679,8 @@ describe(`Core`, () => {
 
         const {positionals} = cli.process([`--foo`, `--bar`]);
         expect(positionals).to.deep.equal([
-            {value: `--foo`, extra: true},
-            {value: `--bar`, extra: true},
+            {value: `--foo`, extra: NoLimits},
+            {value: `--bar`, extra: NoLimits},
         ]);
     });
 


### PR DESCRIPTION
Transformers were consuming positionals in broken ways, which caused things like a `Command.String({required: true})` after a `Command.Rest()` to not work correctly (`Command.String({required: true})` after `Command.String({required: false})` was also broken).

A lot of refactoring had to be done to handle every possible case, but now everything works correctly. (I'm not going to describe how I fixed things here, I've already described enough of my pain on Discord. The tests are all that's needed to understand what went horribly wrong before). I've also updated the documentation to include `Command.Rest` and `Command.Proxy`.