### PR TITLE
Displays the general help when no commands are provided

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -200,7 +200,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
 
         switch (state.selectedIndex) {
             case HELP_COMMAND_INDEX: {
-                return HelpCommand.from<Context>(state, this, contexts);
+                return HelpCommand.from<Context>(state, contexts);
             } break;
 
             default: {

--- a/sources/advanced/HelpCommand.ts
+++ b/sources/advanced/HelpCommand.ts
@@ -7,8 +7,8 @@ export class HelpCommand<Context extends BaseContext> extends Command<Context> {
     private commands: number[] = [];
     private index?: number;
 
-    static from<Context extends BaseContext>(state: RunState, realCli: Cli<Context>, contexts: CliContext<Context>[]) {
-        const command = new HelpCommand<Context>(realCli, contexts);
+    static from<Context extends BaseContext>(state: RunState, contexts: CliContext<Context>[]) {
+        const command = new HelpCommand<Context>(contexts);
         command.path = state.path;
 
         for (const opt of state.options) {
@@ -25,7 +25,7 @@ export class HelpCommand<Context extends BaseContext> extends Command<Context> {
         return command;
     }
 
-    constructor(private readonly realCli: Cli<Context>, private readonly contexts: CliContext<Context>[]) {
+    constructor(private readonly contexts: CliContext<Context>[]) {
         super();
     }
 
@@ -34,15 +34,17 @@ export class HelpCommand<Context extends BaseContext> extends Command<Context> {
         if (typeof this.index !== `undefined` && this.index >= 0 && this.index < commands.length)
             commands = [commands[this.index]];
 
-        if (commands.length === 1) {
-            this.context.stdout.write(this.realCli.usage(this.contexts[commands[0]].commandClass, {detailed: true}));
+        if (commands.length === 0) {
+            this.context.stdout.write(this.cli.usage());
+        } else if (commands.length === 1) {
+            this.context.stdout.write(this.cli.usage(this.contexts[commands[0]].commandClass, {detailed: true}));
         } else if (commands.length > 1) {
             this.context.stdout.write(`Multiple commands match your selection:\n`);
             this.context.stdout.write(`\n`);
 
             let index = 0;
             for (const command of this.commands)
-                this.context.stdout.write(this.realCli.usage(this.contexts[command].commandClass, {prefix: `${index++}. `.padStart(5)}));
+                this.context.stdout.write(this.cli.usage(this.contexts[command].commandClass, {prefix: `${index++}. `.padStart(5)}));
 
             this.context.stdout.write(`\n`);
             this.context.stdout.write(`Run again with -h=<index> to see the longer details of any of those commands.\n`);

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,4 +1,5 @@
 import {expect}                         from 'chai';
+import { HELP_COMMAND_INDEX } from '../sources/constants';
 
 import {CliBuilderCallback, CliBuilder} from '../sources/core';
 
@@ -708,16 +709,15 @@ describe(`Core`, () => {
         }).to.throw(`Extraneous positional argument ("foo")`);
     });
 
-    it(`should throw acceptable errors when a command is incomplete`, () => {
+    it(`should print the help when there's no argv on a CLI without default command`, () => {
         const cli = makeCli([
             b => {
                 b.addPath([`foo`]);
             },
         ]);
 
-        expect(() => {
-            cli.process([]);
-        }).to.throw(`Command not found; did you mean:`);
+        const {selectedIndex} = cli.process([]);
+        expect(selectedIndex).to.equal(HELP_COMMAND_INDEX);
     });
 
     it(`should throw acceptable errors when a command is incomplete (multiple choices)`, () => {
@@ -730,9 +730,20 @@ describe(`Core`, () => {
             },
         ]);
 
+        const {selectedIndex} = cli.process([]);
+        expect(selectedIndex).to.equal(HELP_COMMAND_INDEX);
+    });
+
+    it(`should throw acceptable errors when using an incomplete path`, () => {
+        const cli = makeCli([
+            b => {
+                b.addPath([`foo`, `bar`]);
+            },
+        ]);
+
         expect(() => {
-            cli.process([]);
-        }).to.throw(`Command not found; did you mean one of:`);
+            cli.process([`foo`]);
+        }).to.throw(`Command not found; did you mean`);
     });
 
     it(`should throw acceptable errors when omitting mandatory positional arguments`, () => {


### PR DESCRIPTION
We currently display a fairly unhelpful message when calling CLIs without any parameter and when there is no default command:

```
Unknown Syntax Error: Command not found; did you mean one of:

  0. yarn install [--frozen-lockfile]
  1. yarn remove ...
  2. yarn run [--json]
  3. yarn run <scriptName> ...
  4. yarn add [-D,--dev] [-P,--peer] [-E,--exact] [-T,--tilde] <pkgs> ...

While running
```

This diff changes that to instead print the general help.

```
Yarn Project Manager - v0.0.0

  $ yarn <command>

Where <command> is one of:

  yarn add [-D,--dev] [-P,--peer] [-E,--exact] [-T,--tilde] <pkgs> ...
    add dependencies to the project

  yarn remove ...
    remove dependencies from the project

Script-related commands:

  yarn run <scriptName> ...
    undocumented

You can also print more details about any of these commands by calling them
after adding the `-h,--help` flag right after the command name.
```