### PR TITLE
refactor: improve option definitions

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -393,7 +393,8 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
             result += formatMarkdownish(`You can also print more details about any of these commands by calling them after adding the \`-h,--help\` flag right after the command name.`, {format: this.format(colored), paragraphs: true});
         } else {
             if (!detailed) {
-                result += `${this.format(colored).bold(prefix)}${this.getUsageByRegistration(commandClass)}\n`;
+                const {usage} = this.getUsageByRegistration(commandClass);
+                result += `${this.format(colored).bold(prefix)}${usage}\n`;
             } else {
                 const {
                     description = ``,

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -1,5 +1,4 @@
 import * as errors from './errors';
-import { richFormat } from './format';
 import {
     BATCH_REGEX, BINDING_REGEX, END_OF_INPUT,
     HELP_COMMAND_INDEX, HELP_REGEX, NODE_ERRORED,
@@ -738,15 +737,11 @@ export class CommandBuilder<Context> {
         this.options.push({names, description, arity, hidden, allowBinding});
     }
 
-    getOptions() {
-        return this.options;
-    }
-
     setContext(context: Context) {
         this.context = context;
     }
 
-    usage({detailed = true, showOptionList = false}: {detailed?: boolean; showOptionList?: boolean} = {}) {
+    usage({detailed = true, inlineOptions = true}: {detailed?: boolean; inlineOptions?: boolean} = {}) {
         const segments = [this.cliOpts.binaryName];
 
         const detailedOptionList: {
@@ -768,7 +763,7 @@ export class CommandBuilder<Context> {
 
                 const definition = `${names.join(`,`)}${args.join(``)}`;
 
-                if (showOptionList && description) {
+                if (!inlineOptions && description) {
                     detailedOptionList.push({definition, description});
                 } else {
                     segments.push(`[${definition}]`);
@@ -787,23 +782,7 @@ export class CommandBuilder<Context> {
 
         let usage = segments.join(` `);
 
-        if (detailed) {
-            if (detailedOptionList.length > 0) {
-                usage += `\n\n`;
-                usage += `${richFormat.bold('Options:')}\n`;
-
-                const maxDefinitionLength = detailedOptionList.reduce((length, option) => {
-                    return Math.max(length, option.definition.length);
-                }, 0);
-
-                for (const {definition, description} of detailedOptionList) {
-                    usage += `\n`;
-                    usage += `  ${definition.padEnd(maxDefinitionLength)}    ${description}`;
-                }
-            }
-        }
-
-        return usage;
+        return {usage, options: detailedOptionList};
     }
 
     compile() {


### PR DESCRIPTION
I've experimented with using the option descriptions inside Yarn's CLI docs, but the option definitions have a few problems:
- The options with descriptions weren't excluded from the usage.
- The `options` field also included options without descriptions.
- The `options[].definition` field was simply a join rather than a full definition (which should also include the arity - `-p,--package #0`)

Also, the descriptions weren't formatted as markdown(ish) on the Command help page (useful to highlight backticks).

A small proof of concept of what the option descriptions could look like inside Yarn's CLI docs (after this PR is merged):

![image](https://user-images.githubusercontent.com/32596136/93868277-e85d9400-fcd2-11ea-8546-1f0ba625b810.png)
