### PR TITLE
fix: fix setCandidateUsage

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "rollup": "^2.16.1",
     "ts-node": "^8.10.2",
     "tslib": "^2.0.0",
-    "typescript": "4.0.0-dev.20200729",
+    "typescript": "^4.0.3",
     "yup": "^0.29.1"
   },
   "scripts": {

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -793,7 +793,7 @@ export class CommandBuilder<Context> {
         let firstNode = NODE_INITIAL;
 
         firstNode = injectNode(machine, makeNode());
-        registerStatic(machine, NODE_INITIAL, START_OF_INPUT, firstNode, [`setCandidateUsage`, this.usage()]);
+        registerStatic(machine, NODE_INITIAL, START_OF_INPUT, firstNode, [`setCandidateUsage`, this.usage().usage]);
 
         const positionalArgument = this.arity.proxy
             ? `always`

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -448,11 +448,11 @@ function findCommonPrefix(firstPath: string[], secondPath: string[]|undefined, .
 
 type Transition = {
     to: number;
-    reducer?: Callback<keyof typeof reducers>;
+    reducer?: Callback<keyof typeof reducers, typeof reducers>;
 };
 
 type Node = {
-    dynamics: [Callback<keyof typeof tests>, Transition][];
+    dynamics: [Callback<keyof typeof tests, typeof tests>, Transition][];
     shortcuts: Transition[];
     statics: {[segment: string]: Transition[]};
 };
@@ -491,28 +491,35 @@ export function cloneNode(input: Node, offset: number = 0) {
     return output;
 }
 
-export function registerDynamic(machine: StateMachine, from: number, test: Callback<keyof typeof tests>, to: number, reducer?: Callback<keyof typeof reducers>) {
-    machine.nodes[from].dynamics.push([test, {to, reducer}]);
+export function registerDynamic<T extends keyof typeof tests, R extends keyof typeof reducers>(machine: StateMachine, from: number, test: Callback<T, typeof tests>, to: number, reducer?: Callback<R, typeof reducers>) {
+    machine.nodes[from].dynamics.push([
+        test as Callback<keyof typeof tests, typeof tests>,
+        {to, reducer: reducer as Callback<keyof typeof reducers, typeof reducers>}
+    ]);
 }
 
-export function registerShortcut(machine: StateMachine, from: number, to: number, reducer?: Callback<keyof typeof reducers>) {
-    machine.nodes[from].shortcuts.push({to, reducer});
+export function registerShortcut<R extends keyof typeof reducers>(machine: StateMachine, from: number, to: number, reducer?: Callback<R, typeof reducers>) {
+    machine.nodes[from].shortcuts.push(
+        {to, reducer: reducer as Callback<keyof typeof reducers, typeof reducers>
+    });
 }
 
-export function registerStatic(machine: StateMachine, from: number, test: string, to: number, reducer?: Callback<keyof typeof reducers>) {
+export function registerStatic<R extends keyof typeof reducers>(machine: StateMachine, from: number, test: string, to: number, reducer?: Callback<R, typeof reducers>) {
     let store = !Object.prototype.hasOwnProperty.call(machine.nodes[from].statics, test)
         ? machine.nodes[from].statics[test] = []
         : machine.nodes[from].statics[test];
 
-    store.push({to, reducer});
+    store.push({to, reducer: reducer as Callback<keyof typeof reducers, typeof reducers>});
 }
 
 // ------------------------------------------------------------------------
 
-export type CallbackStore<T extends string> = {[key: string]: (state: RunState, segment: string, ...args: any[]) => {}};
-export type Callback<T extends string> = T | [T, ...any[]];
+export type CallbackFn<P extends any[], R> = (state: RunState, segment: string, ...args: P) => R;
+export type CallbackFnParameters<T extends CallbackFn<any, any>> = T extends ((state: RunState, segment: string, ...args: infer P) => any) ? P : never;
+export type CallbackStore<T extends string, R> = Record<T, CallbackFn<any, R>>;
+export type Callback<T extends string, S extends CallbackStore<T, any>> = T | [T, ...CallbackFnParameters<S[T]>];
 
-export function execute<T extends string>(store: CallbackStore<T>, callback: Callback<T>, state: RunState, segment: string): any {
+export function execute<T extends string, R, S extends CallbackStore<T, R>>(store: S, callback: Callback<T, S>, state: RunState, segment: string) {
     if (Array.isArray(callback)) {
         const [name, ...args] = callback;
         return store[name](state, segment, ...args);
@@ -521,7 +528,7 @@ export function execute<T extends string>(store: CallbackStore<T>, callback: Cal
     }
 }
 
-export function suggest(callback: Callback<keyof typeof tests>, state: RunState): string[] | null {
+export function suggest(callback: Callback<keyof typeof tests, typeof tests>, state: RunState): string[] | null {
     const fn = Array.isArray(callback)
         ? tests[callback[0]]
         : tests[callback];
@@ -548,7 +555,7 @@ export const tests = {
     isNotOptionLike: (state: RunState, segment: string) => {
         return state.ignoreOptions || !segment.startsWith(`-`);
     },
-    isOption: (state: RunState, segment: string, name: string, hidden: boolean) => {
+    isOption: (state: RunState, segment: string, name: string, hidden?: boolean) => {
         return !state.ignoreOptions && segment === name;
     },
     isBatchOption: (state: RunState, segment: string, names: string[]) => {
@@ -921,7 +928,7 @@ export class CommandBuilder<Context> {
                     registerDynamic(machine, node, [`isOption`, name, option.hidden || name !== longestName], node, `pushTrue`);
 
                     if (name.startsWith(`--`)) {
-                        registerDynamic(machine, node, [`isNegatedOption`, name, option.hidden || name !== longestName], node, [`pushFalse`, name]);
+                        registerDynamic(machine, node, [`isNegatedOption`, name], node, [`pushFalse`, name]);
                     }
                 }
             } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,7 +1652,7 @@ __metadata:
     rollup: ^2.16.1
     ts-node: ^8.10.2
     tslib: ^2.0.0
-    typescript: 4.0.0-dev.20200729
+    typescript: ^4.0.3
     yup: ^0.29.1
   languageName: unknown
   linkType: soft
@@ -3606,23 +3606,23 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-typescript@4.0.0-dev.20200729:
-  version: 4.0.0-dev.20200729
-  resolution: "typescript@npm:4.0.0-dev.20200729"
+typescript@^4.0.3:
+  version: 4.0.3
+  resolution: "typescript@npm:4.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3/d2802899d2c7be6d16caa473fb0578102740cecc09160445eb448a3d36f9b96cc5e87ec9ce98565e36c312c2979f4c82b47031a692d1cffe982dff2faac95701
+  checksum: 3/5c892e132756a83d22030d7fb38be47cde27613f71d233dbe7faf79e4a92852c5146bfddcaf8c2da1a37d35ae8bf7b8c888fdcd763d5ad184cea6b21e7466838
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.0.0-dev.20200729#builtin<compat/typescript>":
-  version: 4.0.0-dev.20200729
-  resolution: "typescript@patch:typescript@npm%3A4.0.0-dev.20200729#builtin<compat/typescript>::version=4.0.0-dev.20200729&hash=8cac75"
+"typescript@patch:typescript@^4.0.3#builtin<compat/typescript>":
+  version: 4.0.3
+  resolution: "typescript@patch:typescript@npm%3A4.0.3#builtin<compat/typescript>::version=4.0.3&hash=8cac75"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3/5677e5101028f26d1d8141c89c2c2d08af6184babd9d2ce6ba819cc5e1cd043ae655788ee59758474541870c8d92d9931a8202746bc563f0fb174fafd2ccadbd
+  checksum: 3/1b4008712b0d90daf28ae414af573b75fee2d2895287167794c0c15879cd45822166e50176820bba4414c5b67acf0d3e5e612a6a31e1a5f90aa4f9aab8952a91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When I changed the signature of `commandBuilder.usage` in https://github.com/arcanis/clipanion/pull/46, I forgot to update the `setCandidateUsage` transition. Because `registerStatic` and `registerDynamic` are currently typed as any (I initially thought it was because of objects in template literals, but that wasn't the cause), I didn't notice this until today:

![image](https://user-images.githubusercontent.com/32596136/94340866-bbc8b580-000d-11eb-8325-e69c19325dcb.png)

I've fixed the issue and I've also made it so that the callbacks are strongly typed to prevent such problems in the future.