### PR TITLE
fix: don't allow double negations for options with arity 1

### DIFF
--- a/sources/core.ts
+++ b/sources/core.ts
@@ -920,7 +920,7 @@ export class CommandBuilder<Context> {
                 for (const name of option.names) {
                     registerDynamic(machine, node, [`isOption`, name, option.hidden || name !== longestName], node, `pushTrue`);
 
-                    if (name.startsWith(`--`)) {
+                    if (name.startsWith(`--`) && !name.startsWith(`--no-`)) {
                         registerDynamic(machine, node, [`isNegatedOption`, name, option.hidden || name !== longestName], node, [`pushFalse`, name]);
                     }
                 }

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -878,4 +878,20 @@ describe(`Advanced`, () => {
         expect(cli.process([`foo`, `--bar`])).to.deep.contain({args: [`foo`, `--bar`]});
         expect(cli.process([`foo`, `--bar`, `--baz=1`])).to.deep.contain({args: [`foo`, `--bar`, `--baz=1`]});
     });
+
+    it(`should not allow negating options with arity 1 that already start with "--no-"`, async () => {
+        class FooCommand extends Command {
+            @Command.Boolean(`--no-redacted`)
+            noRedacted: string[] = [];
+
+            async execute() {}
+        }
+
+        const cli = Cli.from([FooCommand]);
+
+        expect(() => cli.process([`--no-redacted`])).not.to.throw();
+        expect(() => cli.process([`--redacted`])).to.throw(`Unsupported option name ("--redacted")`);
+        expect(() => cli.process([`--no-no-redacted`])).to.throw(`Unsupported option name ("--no-no-redacted")`);
+        expect(() => cli.process([`--no-no-no-redacted`])).to.throw(`Unsupported option name ("--no-no-no-redacted")`);
+    });
 });


### PR DESCRIPTION
This PR disallows double negations for options with arity 1, such as writing `--no-no-redacted` for an option called `--no-redacted`. This is because double negations don't make any sense, `--no-redacted` already implies the fact that it's always redacted unless this option is set, no matter how the stars align.