### PR TITLE
build: target es2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,12 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2017"
+      "ES2018"
     ],
     "module": "commonjs",
     "outDir": "lib",
     "strict": true,
-    "target": "es2017"
+    "target": "ES2018"
   },
   "include": [
     "sources/**/*"


### PR DESCRIPTION
**What's the problem this PR addresses?**

The use of object spread is currently transpiled to `Object.assign` but that's unnecessary as object spread has been supported since `node@8.6.0`

**How did you fix it?**

Set build target to ES2018 - only change in build output is object spread