### PR TITLE
docs: update docs on positional inheritance

### DIFF
--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -254,7 +254,7 @@ describe(`Advanced`, () => {
         expect(output).to.equal(`Running CommandA\nRunning CommandB\n`);
     });
 
-    it(`should support inheritance`, async () => {
+    it(`should support inheritance of options`, async () => {
         const output = await runCli(() => {
             abstract class CommandA extends Command {
                 foo = Option.String(`--foo`);
@@ -273,6 +273,28 @@ describe(`Advanced`, () => {
         }, [`--foo`, `hello`]);
 
         expect(output).to.equal(`Running CommandB\n"hello"\n`);
+    });
+
+    it(`should support inheritance of positionals (consumed starting from the superclass)`, async () => {
+        const output = await runCli(() => {
+            abstract class CommandA extends Command {
+                foo = Option.String();
+                abstract execute(): Promise<number | void>;
+            }
+
+            class CommandB extends CommandA {
+                bar = Option.String();
+                async execute() {
+                    log(this, [`foo`, `bar`]);
+                }
+            }
+
+            return [
+                CommandB,
+            ];
+        }, [`hello`, `world`]);
+
+        expect(output).to.equal(`Running CommandB\n"hello"\n"world"\n`);
     });
 
     it(`derives positional argument names from the property name`, async () => {

--- a/website/docs/tips.md
+++ b/website/docs/tips.md
@@ -24,7 +24,7 @@ class FooCommand extends BaseCommand {
 }
 ```
 
-**Note:** Because of the class initialization order, positional arguments of a subclass will be consumed before positional arguments of a superclass. Because of this, it is not recommended to inherit anything other than named options and regular methods.
+**Note:** Positionals can also be inherited. They will be consumed in order starting from the superclass.
 
 ## Lazy evaluation
 

--- a/website/docs/tips.md
+++ b/website/docs/tips.md
@@ -24,7 +24,29 @@ class FooCommand extends BaseCommand {
 }
 ```
 
-**Note:** Positionals can also be inherited. They will be consumed in order starting from the superclass.
+Positionals can also be inherited. They will be consumed in order starting from the superclass:
+
+```ts
+abstract class BaseCommand extends Command {
+    foo = Command.String();
+
+    abstract execute(): Promise<number | void>;
+}
+
+class FooCommand extends BaseCommand {
+    bar = Command.String();
+
+    async execute() {
+        this.context.stdout.write(`This is foo: ${this.foo}.\n`);
+        this.context.stdout.write(`This is bar: ${this.bar}.\n`);
+    }
+}
+```
+
+```
+hello world
+    => Command {"foo": "hello", "bar": "world"}
+```
 
 ## Lazy evaluation
 


### PR DESCRIPTION
The note on positional inheritance was outdated, the consumption order problem only existed because of the decorator evaluation order. It now works as expected since we use regular properties.