### PR TITLE
docs: replace Command.* with Option.* where necessary

### DIFF
--- a/sources/advanced/options/Proxy.ts
+++ b/sources/advanced/options/Proxy.ts
@@ -8,11 +8,11 @@ export type ProxyFlags = {
 /**
  * Used to annotate that the command wants to retrieve all trailing
  * arguments that cannot be tied to a declared option.
- * 
+ *
  * Be careful: this function is order-dependent! Make sure to define it
  * after any positional argument you want to declare.
- * 
- * This function is mutually exclusive with Command.Rest.
+ *
+ * This function is mutually exclusive with Option.Rest.
  *
  * @example
  * yarn run foo hello --foo=bar world

--- a/sources/advanced/options/Rest.ts
+++ b/sources/advanced/options/Rest.ts
@@ -9,12 +9,12 @@ export type RestFlags = {
 /**
  * Used to annotate that the command supports any number of positional
  * arguments.
- * 
+ *
  * Be careful: this function is order-dependent! Make sure to define it
  * after any positional argument you want to declare.
- * 
- * This function is mutually exclusive with Command.Proxy.
- * 
+ *
+ * This function is mutually exclusive with Option.Proxy.
+ *
  * @example
  * yarn add hello world
  *     ► rest = ["hello", "world"]

--- a/website/docs/api/option.md
+++ b/website/docs/api/option.md
@@ -116,7 +116,7 @@ Option.Proxy(opts?: {...})
 | --- | --- | --- |
 | `required` | `number` | Number of required trailing arguments |
 
-Specifies that the command accepts an infinite set of positional arguments that will not be consumed by the options of the `Command` instance. Use this decorator instead of `Command.Rest` when you wish to forward arguments to another command parsing them in any way. By default no arguments are required, but this can be changed by setting the `required` option.
+Specifies that the command accepts an infinite set of positional arguments that will not be consumed by the options of the `Command` instance. Use this decorator instead of `Option.Rest` when you wish to forward arguments to another command parsing them in any way. By default no arguments are required, but this can be changed by setting the `required` option.
 
 ```ts
 class RunCommand extends Command {
@@ -184,7 +184,7 @@ run
 # => TestCommand {"values": []}
 ```
 
-**Note:** Rest arguments are strictly positionals. All options found between rest arguments will be consumed as options of the `Command` instance. If you wish to forward a list of option to another command without having to parse them yourself, use `Command.Proxy` instead.
+**Note:** Rest arguments are strictly positionals. All options found between rest arguments will be consumed as options of the `Command` instance. If you wish to forward a list of option to another command without having to parse them yourself, use `Option.Proxy` instead.
 
 **Note:** Rest arguments can be surrounded by other *finite* *non-optional* positionals such as `Option.String({required: true})`. Having multiple rest arguments in the same command is however invalid.
 

--- a/website/docs/tips.md
+++ b/website/docs/tips.md
@@ -9,13 +9,13 @@ Because they're just plain old ES6 classes, commands can easily extend each othe
 
 ```ts
 abstract class BaseCommand extends Command {
-    cwd = Command.String(`--cwd`, {hidden: true});
+    cwd = Option.String(`--cwd`, {hidden: true});
 
     abstract execute(): Promise<number | void>;
 }
 
 class FooCommand extends BaseCommand {
-    foo = Command.String(`-f,--foo`);
+    foo = Option.String(`-f,--foo`);
 
     async execute() {
         this.context.stdout.write(`Hello from ${this.cwd ?? process.cwd()}!\n`);
@@ -28,13 +28,13 @@ Positionals can also be inherited. They will be consumed in order starting from 
 
 ```ts
 abstract class BaseCommand extends Command {
-    foo = Command.String();
+    foo = Option.String();
 
     abstract execute(): Promise<number | void>;
 }
 
 class FooCommand extends BaseCommand {
-    bar = Command.String();
+    bar = Option.String();
 
     async execute() {
         this.context.stdout.write(`This is foo: ${this.foo}.\n`);

--- a/website/docs/validation.md
+++ b/website/docs/validation.md
@@ -32,8 +32,8 @@ While option-level validation is typically enough, in some cases you need to als
 import * as t from 'typanion';
 
 class MyCommand extends Command {
-    foo = Command.Boolean(`--foo`, false);
-    bar = Command.Boolean(`--bar`, false);
+    foo = Option.Boolean(`--foo`, false);
+    bar = Option.Boolean(`--bar`, false);
 
     static schema = [
         t.hasMutuallyExclusiveKeys([`foo`, `bar`], t.isLiteral(true)),


### PR DESCRIPTION
There were places in the documentation that referenced the outdated `Command.<option>` options.