### PR TITLE
chore: list typanion as a peer dependency with default

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "typanion": "^3.1.0"
   },
+  "peerDependencies": {
+    "typanion": "^3.1.0"
+  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-typescript": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,6 +4628,8 @@ __metadata:
     tslib: ^2.0.0
     typanion: ^3.1.0
     typescript: ^4.1.2
+  peerDependencies:
+    typanion: ^3.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
As we've already discussed, typanion should be listed as a peer dependency with a default (we've tested and all PMs behave semi-acceptably).