### PR TITLE
feat: required options

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -59,6 +59,7 @@ export type Definition = Usage & {
   options: Array<{
     definition: string;
     description?: string;
+    required: boolean;
   }>;
 };
 

--- a/sources/advanced/options/Array.ts
+++ b/sources/advanced/options/Array.ts
@@ -1,6 +1,6 @@
-import {GeneralFlags, CommandOptionReturn, rerouteArguments, makeCommandOption} from "./utils";
+import {GeneralOptionFlags, CommandOptionReturn, rerouteArguments, makeCommandOption} from "./utils";
 
-export type ArrayFlags = GeneralFlags & {
+export type ArrayFlags = GeneralOptionFlags & {
   arity?: number,
 };
 
@@ -12,8 +12,9 @@ export type ArrayFlags = GeneralFlags & {
  * --foo hello --foo bar
  *     ► {"foo": ["hello", "world"]}
  */
+export function Array(descriptor: string, opts: ArrayFlags & {required: true}): CommandOptionReturn<Array<string>>;
 export function Array(descriptor: string, opts?: ArrayFlags): CommandOptionReturn<Array<string> | undefined>;
-export function Array(descriptor: string, initialValue: Array<string>, opts?: ArrayFlags): CommandOptionReturn<Array<string>>;
+export function Array(descriptor: string, initialValue: Array<string>, opts?: Omit<ArrayFlags, 'required'>): CommandOptionReturn<Array<string>>;
 export function Array(descriptor: string, initialValueBase: ArrayFlags | Array<string> | undefined, optsBase?: ArrayFlags) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
   const {arity = 1} = opts;
@@ -30,6 +31,7 @@ export function Array(descriptor: string, initialValueBase: ArrayFlags | Array<s
 
         hidden: opts?.hidden,
         description: opts?.description,
+        required: opts.required,
       });
     },
 

--- a/sources/advanced/options/Array.ts
+++ b/sources/advanced/options/Array.ts
@@ -1,7 +1,7 @@
-import {GeneralOptionFlags, CommandOptionReturn, rerouteArguments, makeCommandOption} from "./utils";
+import {GeneralOptionFlags, CommandOptionReturn, rerouteArguments, makeCommandOption, WithArity} from "./utils";
 
-export type ArrayFlags = GeneralOptionFlags & {
-  arity?: number,
+export type ArrayFlags<Arity extends number = 1> = GeneralOptionFlags & {
+  arity?: Arity,
 };
 
 /**
@@ -12,10 +12,10 @@ export type ArrayFlags = GeneralOptionFlags & {
  * --foo hello --foo bar
  *     ► {"foo": ["hello", "world"]}
  */
-export function Array(descriptor: string, opts: ArrayFlags & {required: true}): CommandOptionReturn<Array<string>>;
-export function Array(descriptor: string, opts?: ArrayFlags): CommandOptionReturn<Array<string> | undefined>;
-export function Array(descriptor: string, initialValue: Array<string>, opts?: Omit<ArrayFlags, 'required'>): CommandOptionReturn<Array<string>>;
-export function Array(descriptor: string, initialValueBase: ArrayFlags | Array<string> | undefined, optsBase?: ArrayFlags) {
+export function Array<Arity extends number = 1>(descriptor: string, opts: ArrayFlags<Arity> & {required: true}): CommandOptionReturn<Array<WithArity<string, Arity>>>;
+export function Array<Arity extends number = 1>(descriptor: string, opts?: ArrayFlags<Arity>): CommandOptionReturn<Array<WithArity<string, Arity>> | undefined>;
+export function Array<Arity extends number = 1>(descriptor: string, initialValue: Array<WithArity<string, Arity>>, opts?: Omit<ArrayFlags<Arity>, 'required'>): CommandOptionReturn<Array<WithArity<string, Arity>>>;
+export function Array<Arity extends number = 1>(descriptor: string, initialValueBase: ArrayFlags<Arity> | Array<WithArity<string, Arity>> | undefined, optsBase?: ArrayFlags<Arity>) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
   const {arity = 1} = opts;
 

--- a/sources/advanced/options/Boolean.ts
+++ b/sources/advanced/options/Boolean.ts
@@ -1,6 +1,6 @@
-import {CommandOptionReturn, GeneralFlags, makeCommandOption, rerouteArguments} from "./utils";
+import {CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments} from "./utils";
 
-export type BooleanFlags = GeneralFlags;
+export type BooleanFlags = GeneralOptionFlags;
 
 /**
  * Used to annotate boolean options.
@@ -9,8 +9,9 @@ export type BooleanFlags = GeneralFlags;
  * --foo --no-bar
  *     ► {"foo": true, "bar": false}
  */
+export function Boolean(descriptor: string, opts: BooleanFlags & {required: true}): CommandOptionReturn<boolean>;
 export function Boolean(descriptor: string, opts?: BooleanFlags): CommandOptionReturn<boolean | undefined>;
-export function Boolean(descriptor: string, initialValue: boolean, opts?: BooleanFlags): CommandOptionReturn<boolean>;
+export function Boolean(descriptor: string, initialValue: boolean, opts?: Omit<BooleanFlags, 'required'>): CommandOptionReturn<boolean>;
 export function Boolean(descriptor: string, initialValueBase: BooleanFlags | boolean | undefined, optsBase?: BooleanFlags) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
 
@@ -27,6 +28,7 @@ export function Boolean(descriptor: string, initialValueBase: BooleanFlags | boo
 
         hidden: opts.hidden,
         description: opts.description,
+        required: opts.required,
       });
     },
 

--- a/sources/advanced/options/Counter.ts
+++ b/sources/advanced/options/Counter.ts
@@ -1,6 +1,6 @@
-import {CommandOptionReturn, GeneralFlags, makeCommandOption, rerouteArguments} from "./utils";
+import {CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments} from "./utils";
 
-export type CounterFlags = GeneralFlags;
+export type CounterFlags = GeneralOptionFlags;
 
 /**
  * Used to annotate options whose repeated values are aggregated into a
@@ -10,8 +10,9 @@ export type CounterFlags = GeneralFlags;
  * -vvvvv
  *     ► {"v": 5}
  */
+export function Counter(descriptor: string, opts: CounterFlags & {required: true}): CommandOptionReturn<number>;
 export function Counter(descriptor: string, opts?: CounterFlags): CommandOptionReturn<number | undefined>;
-export function Counter(descriptor: string, initialValue: number, opts?: CounterFlags): CommandOptionReturn<number>;
+export function Counter(descriptor: string, initialValue: number, opts?: Omit<CounterFlags, 'required'>): CommandOptionReturn<number>;
 export function Counter(descriptor: string, initialValueBase: CounterFlags | number | undefined, optsBase?: CounterFlags) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
 
@@ -28,6 +29,7 @@ export function Counter(descriptor: string, initialValueBase: CounterFlags | num
 
         hidden: opts.hidden,
         description: opts.description,
+        required: opts.required,
       });
     },
 

--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -31,8 +31,8 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
 function StringOption<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
 function StringOption<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
 function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
-function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<Exclude<T, string> | string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
-function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValueBase: StringOption<T> | WithArity<Exclude<T, string> | string, Arity> | string | boolean | undefined, optsBase?: StringOption<T>) {
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValueBase: StringOption<T> | WithArity<string, Arity> | string | boolean | undefined, optsBase?: StringOption<T>) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
   const {arity = 1} = opts;
 
@@ -137,7 +137,7 @@ export function String<T = string, Arity extends number = 1>(descriptor: string,
 export function String<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
 export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
 export function String<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
-export function String<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<Exclude<T, string> | string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
+export function String<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
 
 // This function is badly typed, but it doesn't matter because the overloads provide the true public typings
 export function String(descriptor?: unknown, ...args: Array<any>) {

--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -1,16 +1,16 @@
-import {StrictValidator}                                                                        from "typanion";
+import {StrictValidator}                                                                              from "typanion";
 
-import {NoLimits}                                                                               from "../../core";
+import {NoLimits}                                                                                     from "../../core";
 
-import {applyValidator, CommandOptionReturn, GeneralFlags, makeCommandOption, rerouteArguments} from "./utils";
+import {applyValidator, CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments} from "./utils";
 
-export type StringOptionNoBoolean<T> = GeneralFlags & {
+export type StringOptionNoBoolean<T> = GeneralOptionFlags & {
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean?: false,
   arity?: number,
 };
 
-export type StringOptionTolerateBoolean<T> = GeneralFlags & {
+export type StringOptionTolerateBoolean<T> = GeneralOptionFlags & {
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean: boolean,
   arity?: 1,
@@ -26,10 +26,12 @@ export type StringPositionalFlags<T> = {
   required?: boolean,
 };
 
+function StringOption<T = string>(descriptor: string, opts: StringOptionNoBoolean<T> & {required: true}): CommandOptionReturn<T>;
 function StringOption<T = string>(descriptor: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T | undefined>;
-function StringOption<T = string>(descriptor: string, initialValue: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T>;
+function StringOption<T = string>(descriptor: string, initialValue: string, opts?: Omit<StringOptionNoBoolean<T>, 'required'>): CommandOptionReturn<T>;
+function StringOption<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
 function StringOption<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
-function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean>;
+function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
 function StringOption<T = string>(descriptor: string, initialValueBase: StringOption<T> | string | boolean | undefined, optsBase?: StringOption<T>) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
   const {arity = 1} = opts;
@@ -46,6 +48,7 @@ function StringOption<T = string>(descriptor: string, initialValueBase: StringOp
 
         hidden: opts.hidden,
         description: opts.description,
+        required: opts.required,
       });
     },
 
@@ -129,10 +132,13 @@ export function String<T = string>(opts: StringPositionalFlags<T>): CommandOptio
  * --foo=hello --bar world
  *     ► {"foo": "hello", "bar": "world"}
  */
+export function String<T = string>(descriptor: string, opts: StringOptionNoBoolean<T> & {required: true}): CommandOptionReturn<T>;
 export function String<T = string>(descriptor: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T | undefined>;
-export function String<T = string>(descriptor: string, initialValue: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T>;
+export function String<T = string>(descriptor: string, initialValue: string, opts?: Omit<StringOptionNoBoolean<T>, 'required'>): CommandOptionReturn<T>;
+export function String<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
 export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
-export function String<T = string>(descriptor: string, initialValue: string | boolean, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean>;
+export function String<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
+export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
 
 // This function is badly typed, but it doesn't matter because the overloads provide the true public typings
 export function String(descriptor?: unknown, ...args: Array<any>) {

--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -1,19 +1,19 @@
-import {StrictValidator}                                                                              from "typanion";
+import {StrictValidator}                                                                                         from "typanion";
 
-import {NoLimits}                                                                                     from "../../core";
+import {NoLimits}                                                                                                from "../../core";
 
-import {applyValidator, CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments} from "./utils";
+import {applyValidator, CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments, WithArity} from "./utils";
 
-export type StringOptionNoBoolean<T> = GeneralOptionFlags & {
+export type StringOptionNoBoolean<T, Arity extends number = 1> = GeneralOptionFlags & {
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean?: false,
-  arity?: number,
+  arity?: Arity,
 };
 
 export type StringOptionTolerateBoolean<T> = GeneralOptionFlags & {
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean: boolean,
-  arity?: 1,
+  arity?: 0,
 };
 
 export type StringOption<T> =
@@ -26,13 +26,13 @@ export type StringPositionalFlags<T> = {
   required?: boolean,
 };
 
-function StringOption<T = string>(descriptor: string, opts: StringOptionNoBoolean<T> & {required: true}): CommandOptionReturn<T>;
-function StringOption<T = string>(descriptor: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T | undefined>;
-function StringOption<T = string>(descriptor: string, initialValue: string, opts?: Omit<StringOptionNoBoolean<T>, 'required'>): CommandOptionReturn<T>;
 function StringOption<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, opts: StringOptionNoBoolean<T, Arity> & {required: true}): CommandOptionReturn<WithArity<T, Arity>>;
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
 function StringOption<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
 function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
-function StringOption<T = string>(descriptor: string, initialValueBase: StringOption<T> | string | boolean | undefined, optsBase?: StringOption<T>) {
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<Exclude<T, string> | string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
+function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValueBase: StringOption<T> | WithArity<Exclude<T, string> | string, Arity> | string | boolean | undefined, optsBase?: StringOption<T>) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
   const {arity = 1} = opts;
 
@@ -132,13 +132,12 @@ export function String<T = string>(opts: StringPositionalFlags<T>): CommandOptio
  * --foo=hello --bar world
  *     ► {"foo": "hello", "bar": "world"}
  */
-export function String<T = string>(descriptor: string, opts: StringOptionNoBoolean<T> & {required: true}): CommandOptionReturn<T>;
-export function String<T = string>(descriptor: string, opts?: StringOptionNoBoolean<T>): CommandOptionReturn<T | undefined>;
-export function String<T = string>(descriptor: string, initialValue: string, opts?: Omit<StringOptionNoBoolean<T>, 'required'>): CommandOptionReturn<T>;
 export function String<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
+export function String<T = string, Arity extends number = 1>(descriptor: string, opts: StringOptionNoBoolean<T, Arity> & {required: true}): CommandOptionReturn<WithArity<T, Arity>>;
+export function String<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
 export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
 export function String<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
-export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
+export function String<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<Exclude<T, string> | string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
 
 // This function is badly typed, but it doesn't matter because the overloads provide the true public typings
 export function String(descriptor?: unknown, ...args: Array<any>) {

--- a/sources/advanced/options/utils.ts
+++ b/sources/advanced/options/utils.ts
@@ -6,9 +6,10 @@ import {BaseContext, CliContext}   from '../Cli';
 
 export const isOptionSymbol = Symbol(`clipanion/isOption`);
 
-export type GeneralFlags = {
+export type GeneralOptionFlags = {
   description?: string,
   hidden?: boolean,
+  required?: boolean;
 };
 
 export type CommandOption<T> = {

--- a/sources/advanced/options/utils.ts
+++ b/sources/advanced/options/utils.ts
@@ -12,6 +12,26 @@ export type GeneralOptionFlags = {
   required?: boolean;
 };
 
+// https://stackoverflow.com/a/52490977
+
+export type TupleOf<Type, Arity extends number, Accumulator extends Array<Type>> = Accumulator['length'] extends Arity
+  ? Accumulator
+  : TupleOf<Type, Arity, [Type, ...Accumulator]>;
+
+export type Tuple<Type, Arity extends number> = Arity extends Arity
+  ? number extends Arity
+    ? Array<Type>
+    : TupleOf<Type, Arity, []>
+  : never;
+
+export type WithArity<Type, Arity extends number> = Arity extends 0
+  ? boolean
+  : Arity extends 1
+    ? Type
+    : number extends Arity
+      ? boolean | Type | Tuple<Type, Arity>
+      : Tuple<Type, Arity>;
+
 export type CommandOption<T> = {
   [isOptionSymbol]: true,
   definition: <Context extends BaseContext>(builder: CommandBuilder<CliContext<Context>>, key: string) => void,

--- a/sources/core.ts
+++ b/sources/core.ts
@@ -392,7 +392,7 @@ export function selectBestState(input: Array<string>, states: Array<RunState>) {
   );
 
   if (requiredOptionsSetStates.length === 0) {
-    throw new errors.UnknownSyntaxError(input, states.map(state => ({
+    throw new errors.UnknownSyntaxError(input, terminalStates.map(state => ({
       usage: state.candidateUsage!,
       reason: null,
     })));

--- a/sources/demos/advanced.ts
+++ b/sources/demos/advanced.ts
@@ -133,6 +133,14 @@ class YarnRemove extends Command<Context> {
   }
 }
 
+class YarnWorkspacesForeachCommand extends Command<Context> {
+  include = Option.Array(`--include`);
+
+  static paths = [[`workspaces`, `foreach`]];
+  async execute() {
+  }
+}
+
 const cli = new Cli<Context>({
   binaryLabel: `Yarn Project Manager`,
   binaryName: `yarn`,
@@ -149,6 +157,7 @@ cli.register(YarnRemove);
 cli.register(YarnRunListing);
 cli.register(YarnRunExec);
 cli.register(YarnAdd);
+cli.register(YarnWorkspacesForeachCommand);
 
 cli.runExit(process.argv.slice(2), {
   cwd: process.cwd(),

--- a/sources/errors.ts
+++ b/sources/errors.ts
@@ -29,9 +29,10 @@ export class UnknownSyntaxError extends Error {
 
     if (this.candidates.length === 0) {
       this.message = `Command not found, but we're not sure what's the alternative.`;
-    } else if (this.candidates.length === 1 && this.candidates[0].reason !== null) {
-      const [{usage, reason}] = this.candidates;
-      this.message = `${reason}\n\n$ ${usage}`;
+    } else if (this.candidates.every(candidate => candidate.reason !== null && candidate.reason === candidates[0].reason) ) {
+      const [{reason}] = this.candidates;
+
+      this.message = `${reason}\n\n${this.candidates.map(({usage}) => `$ ${usage}`).join(`\n`)}`;
     } else if (this.candidates.length === 1) {
       const [{usage}] = this.candidates;
       this.message = `Command not found; did you mean:\n\n$ ${usage}\n${whileRunning(input)}`;

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -956,4 +956,35 @@ describe(`Advanced`, () => {
     await expect(runCli(cli, [`--bar`])).to.be.rejectedWith(`Command not found; did you mean one of:`);
     expect(await runCli(cli, [`--foo`, `--bar`])).to.equal(`Running FooBarCommand\n`);
   });
+
+  it(`should show the reason if the single branch errors`, async () => {
+    class BaseCommand extends Command {
+      name = Option.String();
+
+      async execute() {
+        log(this);
+      }
+    }
+
+    const cli = Cli.from([BaseCommand]);
+
+    await expect(runCli(cli, [])).to.be.rejectedWith(`Not enough positional arguments.`);
+  });
+
+  it(`should show the common reason if all branches error with the same reason`, async () => {
+    class BaseCommand extends Command {
+      name = Option.String();
+
+      async execute() {
+        log(this);
+      }
+    }
+    class FooCommand extends BaseCommand {
+      foo = Option.Boolean(`--foo`, {required: true});
+    }
+
+    const cli = Cli.from([BaseCommand, FooCommand]);
+
+    await expect(runCli(cli, [])).to.be.rejectedWith(`Not enough positional arguments.`);
+  });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -955,7 +955,7 @@ describe(`Advanced`, () => {
 
     await expect(runCli(cli, [])).to.be.rejectedWith(`Command not found; did you mean one of:`);
     expect(await runCli(cli, [`--foo`])).to.equal(`Running FooCommand\n`);
-    await expect(runCli(cli, [`--bar`])).to.be.rejectedWith(`Command not found; did you mean one of:`);
+    await expect(runCli(cli, [`--bar`])).to.be.rejectedWith(`Command not found; did you mean:`);
     expect(await runCli(cli, [`--foo`, `--bar`])).to.equal(`Running FooBarCommand\n`);
   });
 

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -934,4 +934,26 @@ describe(`Advanced`, () => {
     expect(await runCli(cli, [`--bar`])).to.equal(`Running BarCommand\n`);
     expect(await runCli(cli, [`--foo`, `--bar`])).to.equal(`Running FooBarCommand\n`);
   });
+
+  it(`should disambiguate an inheriting command from the parent by required options`, async () => {
+    class BaseCommand extends Command {
+      async execute() {
+        log(this);
+      }
+    }
+    class FooCommand extends BaseCommand {
+      foo = Option.Boolean(`--foo`, {required: true});
+    }
+
+    class FooBarCommand extends FooCommand {
+      bar = Option.Boolean(`--bar`, {required: true});
+    }
+
+    const cli = Cli.from([FooCommand, FooBarCommand]);
+
+    await expect(runCli(cli, [])).to.be.rejectedWith(`Command not found; did you mean one of:`);
+    expect(await runCli(cli, [`--foo`])).to.equal(`Running FooCommand\n`);
+    await expect(runCli(cli, [`--bar`])).to.be.rejectedWith(`Command not found; did you mean one of:`);
+    expect(await runCli(cli, [`--foo`, `--bar`])).to.equal(`Running FooBarCommand\n`);
+  });
 });

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -555,6 +555,7 @@ describe(`Advanced`, () => {
 
   it(`should throw acceptable errors when tuple length is not an integer`, async () => {
     class PointCommand extends Command {
+      // @ts-expect-error: Even TS realizes that the arity is wrong
       point = Option.String(`--point`, {arity: 1.5});
       async execute() {}
     }
@@ -566,6 +567,7 @@ describe(`Advanced`, () => {
 
   it(`should throw acceptable errors when tuple length is not positive`, async () => {
     class PointCommand extends Command {
+      // @ts-expect-error: Even TS realizes that the arity is wrong
       point = Option.String(`--point`, {arity: -1});
       async execute() {}
     }
@@ -986,5 +988,20 @@ describe(`Advanced`, () => {
     const cli = Cli.from([BaseCommand, FooCommand]);
 
     await expect(runCli(cli, [])).to.be.rejectedWith(`Not enough positional arguments.`);
+  });
+
+  it(`should treat arity 0 as booleans`, async () => {
+    class PointCommand extends Command {
+      point = Option.String(`--point`, {arity: 0});
+
+      thing = Option.Array(`--thing`, {arity: 0})
+
+      async execute() {}
+    }
+
+    const cli = Cli.from([PointCommand]);
+
+    expect(cli.process([`--point`])).to.deep.contain({point: true});
+    expect(cli.process([`--thing`, `--thing`, `--no-thing`, `--thing`])).to.deep.contain({thing: [true, true, false, true]});
   });
 });

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -23,12 +23,29 @@ class MyCommand extends Command {
   stringWithDefault = Option.String(`--foo`, false);
   stringWithValidator = Option.String(`--foo`, {validator: t.isNumber()});
   stringWithValidatorAndDefault = Option.String(`--foo`, `0`, {validator: t.isNumber()});
-  stringWithTolerateBoolean = Option.String(`--foo`, {tolerateBoolean: true});
-  stringWithTolerateBooleanAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true});
+  stringWithValidatorAndCoercedDefault = Option.String(`--foo`, 0, {validator: t.isNumber()});
+  stringWithValidatorAndRequired = Option.String(`--foo`, {validator: t.isNumber(), required: true});
   stringWithRequired = Option.String(`--foo`, {required: true});
-  stringWithTolerateBooleanAndRequired = Option.String(`--foo`, {tolerateBoolean: true, required: true});
   // @ts-expect-error: Overload prevents this
   stringWithRequiredAndDefault = Option.String(`--foo`, false, {required: true});
+  stringWithArity0 = Option.String(`--foo`, {arity: 0});
+  stringWithArity1 = Option.String(`--foo`, {arity: 1});
+  stringWithArity2 = Option.String(`--foo`, {arity: 2});
+  stringWithArity3 = Option.String(`--foo`, {arity: 3});
+  stringWithArity3AndDefault = Option.String(`--foo`, [`bar`, `baz`, `qux`], {arity: 3});
+  // @ts-expect-error: Overload prevents this
+  stringWithArity3AndWrongDefault = Option.String(`--foo`, `bar`, {arity: 3});
+  stringWithArity3AndValidator = Option.String(`--foo`, {arity: 3, validator: t.isNumber()});
+  stringWithArity3AndValidatorAndDefault = Option.String(`--foo`, [`1`, `2`, `3`], {arity: 3, validator: t.isNumber()});
+  stringWithArity3AndValidatorAndCoercedDefault = Option.String(`--foo`, [1, `2`, 3], {arity: 3, validator: t.isNumber()});
+  stringWithArity3AndValidatorAndRequired = Option.String(`--foo`, {arity: 3, validator: t.isNumber(), required: true});
+  stringWithArity3AndRequired = Option.String(`--foo`, {arity: 3, required: true});
+  // @ts-expect-error: Overload prevents this
+  stringWithArity3AndRequiredAndDefault = Option.String(`--foo`, [`bar`, `baz`, `qux`], {arity: 3, required: true});
+
+  stringWithTolerateBoolean = Option.String(`--foo`, {tolerateBoolean: true});
+  stringWithTolerateBooleanAndRequired = Option.String(`--foo`, {tolerateBoolean: true, required: true});
+  stringWithTolerateBooleanAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true});
   // @ts-expect-error: Overload prevents this
   stringWithTolerateBooleanAndRequiredAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true, required: true});
 
@@ -43,6 +60,14 @@ class MyCommand extends Command {
   arrayWithRequired = Option.Array(`--foo`, {required: true});
   // @ts-expect-error: Overload prevents this
   arrayWithRequiredAndDefault = Option.Array(`--foo`, [], {required: true});
+  arrayWithArity0 = Option.Array(`--foo`, {arity: 0});
+  arrayWithArity1 = Option.Array(`--foo`, {arity: 1});
+  arrayWithArity2 = Option.Array(`--foo`, {arity: 2});
+  arrayWithArity3 = Option.Array(`--foo`, {arity: 3});
+  arrayWithArity3AndDefault = Option.Array(`--foo`, [], {arity: 3});
+  arrayWithArity3AndRequired = Option.Array(`--foo`, {arity: 3, required: true});
+  // @ts-expect-error: Overload prevents this
+  arrayWithArity3AndRequiredAndDefault = Option.Array(`--foo`, [], {arity: 3, required: true});
 
   rest = Option.Rest();
   proxy = Option.Proxy();
@@ -56,14 +81,26 @@ class MyCommand extends Command {
     assertEqual<boolean>()(this.booleanWithRequired, true);
 
     assertEqual<string | undefined>()(this.string, true);
-    assertEqual<string | undefined>()(this.string, true);
     assertEqual<string | boolean>()(this.stringWithDefault, true);
     assertEqual<string | boolean>()(this.stringWithDefault, true);
     assertEqual<number | undefined>()(this.stringWithValidator, true);
+    assertEqual<number>()(this.stringWithValidatorAndRequired, true);
     assertEqual<number>()(this.stringWithValidatorAndDefault, true);
+    assertEqual<number>()(this.stringWithValidatorAndCoercedDefault, true);
+    assertEqual<string>()(this.stringWithRequired, true);
+    assertEqual<boolean | undefined>()(this.stringWithArity0, true);
+    assertEqual<string | undefined>()(this.stringWithArity1, true);
+    assertEqual<[string, string] | undefined>()(this.stringWithArity2, true);
+    assertEqual<[string, string, string] | undefined>()(this.stringWithArity3, true);
+    assertEqual<[string, string, string]>()(this.stringWithArity3AndDefault, true);
+    assertEqual<[string, string, string]>()(this.stringWithArity3AndRequired, true);
+    assertEqual<[number, number, number] | undefined>()(this.stringWithArity3AndValidator, true);
+    assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndDefault, true);
+    assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndCoercedDefault, true);
+    assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndRequired, true);
+
     assertEqual<string | boolean | undefined>()(this.stringWithTolerateBoolean, true);
     assertEqual<string | boolean>()(this.stringWithTolerateBooleanAndDefault, true);
-    assertEqual<string>()(this.stringWithRequired, true);
     assertEqual<string | boolean>()(this.stringWithTolerateBooleanAndRequired, true);
 
     assertEqual<number | undefined>()(this.counter, true);
@@ -73,6 +110,12 @@ class MyCommand extends Command {
     assertEqual<Array<string> | undefined>()(this.array, true);
     assertEqual<Array<string>>()(this.arrayWithDefault, true);
     assertEqual<Array<string>>()(this.arrayWithRequired, true);
+    assertEqual<Array<boolean> | undefined>()(this.arrayWithArity0, true);
+    assertEqual<Array<string> | undefined>()(this.arrayWithArity1, true);
+    assertEqual<Array<[string, string]> | undefined>()(this.arrayWithArity2, true);
+    assertEqual<Array<[string, string, string]> | undefined>()(this.arrayWithArity3, true);
+    assertEqual<Array<[string, string, string]>>()(this.arrayWithArity3AndDefault, true);
+    assertEqual<Array<[string, string, string]>>()(this.arrayWithArity3AndRequired, true);
 
     assertEqual<Array<string>>()(this.rest, true);
     assertEqual<Array<string>>()(this.proxy, true);

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -23,7 +23,6 @@ class MyCommand extends Command {
   stringWithDefault = Option.String(`--foo`, false);
   stringWithValidator = Option.String(`--foo`, {validator: t.isNumber()});
   stringWithValidatorAndDefault = Option.String(`--foo`, `0`, {validator: t.isNumber()});
-  stringWithValidatorAndCoercedDefault = Option.String(`--foo`, 0, {validator: t.isNumber()});
   stringWithValidatorAndRequired = Option.String(`--foo`, {validator: t.isNumber(), required: true});
   stringWithRequired = Option.String(`--foo`, {required: true});
   // @ts-expect-error: Overload prevents this
@@ -37,7 +36,6 @@ class MyCommand extends Command {
   stringWithArity3AndWrongDefault = Option.String(`--foo`, `bar`, {arity: 3});
   stringWithArity3AndValidator = Option.String(`--foo`, {arity: 3, validator: t.isNumber()});
   stringWithArity3AndValidatorAndDefault = Option.String(`--foo`, [`1`, `2`, `3`], {arity: 3, validator: t.isNumber()});
-  stringWithArity3AndValidatorAndCoercedDefault = Option.String(`--foo`, [1, `2`, 3], {arity: 3, validator: t.isNumber()});
   stringWithArity3AndValidatorAndRequired = Option.String(`--foo`, {arity: 3, validator: t.isNumber(), required: true});
   stringWithArity3AndRequired = Option.String(`--foo`, {arity: 3, required: true});
   // @ts-expect-error: Overload prevents this
@@ -86,7 +84,6 @@ class MyCommand extends Command {
     assertEqual<number | undefined>()(this.stringWithValidator, true);
     assertEqual<number>()(this.stringWithValidatorAndRequired, true);
     assertEqual<number>()(this.stringWithValidatorAndDefault, true);
-    assertEqual<number>()(this.stringWithValidatorAndCoercedDefault, true);
     assertEqual<string>()(this.stringWithRequired, true);
     assertEqual<boolean | undefined>()(this.stringWithArity0, true);
     assertEqual<string | undefined>()(this.stringWithArity1, true);
@@ -96,7 +93,6 @@ class MyCommand extends Command {
     assertEqual<[string, string, string]>()(this.stringWithArity3AndRequired, true);
     assertEqual<[number, number, number] | undefined>()(this.stringWithArity3AndValidator, true);
     assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndDefault, true);
-    assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndCoercedDefault, true);
     assertEqual<[number, number, number]>()(this.stringWithArity3AndValidatorAndRequired, true);
 
     assertEqual<string | boolean | undefined>()(this.stringWithTolerateBoolean, true);

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -15,17 +15,34 @@ class MyCommand extends Command {
 
   boolean = Option.Boolean(`--foo`);
   booleanWithDefault = Option.Boolean(`--foo`, false);
+  booleanWithRequired = Option.Boolean(`--foo`, {required: true});
+  // @ts-expect-error: Overload prevents this
+  booleanWithRequiredAndDefault = Option.Boolean(`--foo`, false, {required: true});
 
   string = Option.String(`--foo`);
   stringWithDefault = Option.String(`--foo`, false);
   stringWithValidator = Option.String(`--foo`, {validator: t.isNumber()});
   stringWithValidatorAndDefault = Option.String(`--foo`, `0`, {validator: t.isNumber()});
+  stringWithTolerateBoolean = Option.String(`--foo`, {tolerateBoolean: true});
+  stringWithTolerateBooleanAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true});
+  stringWithRequired = Option.String(`--foo`, {required: true});
+  stringWithTolerateBooleanAndRequired = Option.String(`--foo`, {tolerateBoolean: true, required: true});
+  // @ts-expect-error: Overload prevents this
+  stringWithRequiredAndDefault = Option.String(`--foo`, false, {required: true});
+  // @ts-expect-error: Overload prevents this
+  stringWithTolerateBooleanAndRequiredAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true, required: true});
 
   counter = Option.Counter(`--foo`);
   counterWithDefault = Option.Counter(`--foo`, 0);
+  counterWithRequired = Option.Counter(`--foo`, {required: true});
+  // @ts-expect-error: Overload prevents this
+  counterWithRequiredAndDefault = Option.Counter(`--foo`, 0, {required: true});
 
   array = Option.Array(`--foo`);
   arrayWithDefault = Option.Array(`--foo`, []);
+  arrayWithRequired = Option.Array(`--foo`, {required: true});
+  // @ts-expect-error: Overload prevents this
+  arrayWithRequiredAndDefault = Option.Array(`--foo`, [], {required: true});
 
   rest = Option.Rest();
   proxy = Option.Proxy();
@@ -36,6 +53,7 @@ class MyCommand extends Command {
 
     assertEqual<boolean | undefined>()(this.boolean, true);
     assertEqual<boolean>()(this.booleanWithDefault, true);
+    assertEqual<boolean>()(this.booleanWithRequired, true);
 
     assertEqual<string | undefined>()(this.string, true);
     assertEqual<string | undefined>()(this.string, true);
@@ -43,9 +61,18 @@ class MyCommand extends Command {
     assertEqual<string | boolean>()(this.stringWithDefault, true);
     assertEqual<number | undefined>()(this.stringWithValidator, true);
     assertEqual<number>()(this.stringWithValidatorAndDefault, true);
+    assertEqual<string | boolean | undefined>()(this.stringWithTolerateBoolean, true);
+    assertEqual<string | boolean>()(this.stringWithTolerateBooleanAndDefault, true);
+    assertEqual<string>()(this.stringWithRequired, true);
+    assertEqual<string | boolean>()(this.stringWithTolerateBooleanAndRequired, true);
 
     assertEqual<number | undefined>()(this.counter, true);
     assertEqual<number>()(this.counterWithDefault, true);
+    assertEqual<number>()(this.counterWithRequired, true);
+
+    assertEqual<Array<string> | undefined>()(this.array, true);
+    assertEqual<Array<string>>()(this.arrayWithDefault, true);
+    assertEqual<Array<string>>()(this.arrayWithRequired, true);
 
     assertEqual<Array<string>>()(this.rest, true);
     assertEqual<Array<string>>()(this.proxy, true);

--- a/website/docs/api/option.md
+++ b/website/docs/api/option.md
@@ -22,6 +22,7 @@ Option.Array(optionNames: string, default?: string[], opts?: {...})
 | `arity` | `number` | Number of arguments for the option |
 | `description` | `string`| Short description for the help message |
 | `hidden` | `boolean` | Hide the option from any usage list |
+| `required` | `boolean` | Whether at least a single occurrence of the option is required or not |
 
 Specifies that the command accepts a set of string arguments. The `arity` parameter defines how many values need to be accepted for each item. If no default value is provided, the option will start as `undefined`.
 
@@ -53,6 +54,7 @@ Option.Boolean(optionNames: string, default?: boolean, opts?: {...})
 | --- | --- | --- |
 | `description` | `string`| Short description for the help message |
 | `hidden` | `boolean` | Hide the option from any usage list |
+| `required` | `boolean` | Whether at least a single occurrence of the option is required or not |
 
 Specifies that the command accepts a boolean flag as an option. If no default value is provided, the option will start as `undefined`.
 
@@ -80,6 +82,7 @@ Option.Counter(optionNames: string, default?: number, opts?: {...})
 | --- | --- | --- |
 | `description` | `string`| Short description for the help message |
 | `hidden` | `boolean` | Hide the option from any usage list |
+| `required` | `boolean` | Whether at least a single occurrence of the option is required or not |
 
 Specifies that the command accepts a boolean flag as an option. Contrary to classic boolean options, each detected occurence will cause the counter to be incremented. Each time the argument is negated (`--no-<name>`), the counter will be reset to `0`. If no default value is provided, the option will start as `undefined`.
 
@@ -234,6 +237,7 @@ Option.String(optionNames: string, default?: string, opts?: {...})
 | `description` | `string`| Short description for the help message |
 | `hidden` | `boolean` | Hide the option from any usage list |
 | `tolerateBoolean` | `boolean` | Accept the option even if no argument is provided |
+| `required` | `boolean` | Whether at least a single occurrence of the option is required or not |
 
 Specifies that the command accepts an option that takes arguments (by default one, unless overriden via `arity`). If no default value is provided, the option will start as `undefined`.
 

--- a/website/docs/paths.md
+++ b/website/docs/paths.md
@@ -54,5 +54,5 @@ class FooBarCommand extends Command {
 Clipanion will property execute `FooBarCommand` when running `foo bar`, and `FooCommand` when running just `foo`. You can even declare positional arguments on `FooCommand` if you want, which will get picked up as long as they don't match `bar`!
 
 :::tip
-You can even have multiple commands that have identical paths but different options, as long as the user specifies an option unique to one of them when invoking the command! The only caveat is that if they don't Clipanion won't know which version to use and will throw a `AmbiguousSyntaxError`.
+You can even have multiple commands that have identical paths but different options, as long as the user specifies an option unique to one of them (or doesn't if the option is required) when invoking the command! The only caveat is that if they don't Clipanion won't know which version to use and will throw a `AmbiguousSyntaxError`.
 :::

--- a/website/docs/tips.md
+++ b/website/docs/tips.md
@@ -48,6 +48,49 @@ hello world
     => Command {"foo": "hello", "bar": "world"}
 ```
 
+## Adding options to existing commands
+
+Adding options to existing commands can be achieved via inheritance and required options:
+
+```ts
+class GreetCommand extends Command {
+  name = Option.String();
+
+  greeting = Option.String(`--greeting`, `Hello`);
+
+  static paths = [[`greet`]];
+  async execute(): Promise<number | void> {
+    this.context.stdout.write(`${this.greeting} ${this.name}!\n`);
+  }
+}
+
+class GreetWithReverseCommand extends GreetCommand {
+  reverse = Option.Boolean(`--reverse`, {required: true});
+
+  async execute() {
+    return await this.cli.run([`greet`, this.reverse ? this.name.split(``).reverse().join(``) : this.name, `--greeting`, this.greeting]);
+  }
+}
+```
+
+```
+greet john
+    => "Hello john!\n"
+
+greet john --greeting hey
+    => "hey john!\n"
+
+greet john --reverse
+    => "Hello nhoj!\n"
+
+greet john --greeting hey --reverse
+    => "hey nhoj!\n"
+```
+
+:::danger
+To add an option to an existing command, you need to know its `Command` class. This means that if you want to add 2 options by using 2 different commands (e.g. if your application uses different plugins that can register their own commands), you need one of the `Command` classes to extend the other one and not the base.
+:::
+
 ## Lazy evaluation
 
 Many commands have the following form:


### PR DESCRIPTION
Options can now also be required, which will cause an `UnknownSyntaxError` to be thrown if one of the required options is missing. It also allows commands to be disambiguated by their required options (see the tests).