### PR TITLE
feat: print used flag instead of property name in validation error

### DIFF
--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -53,19 +53,21 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
     },
 
     transformer(builder, key, state) {
+      let usedName;
       let currentValue = initialValue;
 
       for (const {name, value} of state.options) {
         if (!nameSet.has(name))
           continue;
 
+        usedName = name;
         currentValue = value;
       }
 
       if (typeof initialValue === `undefined` && typeof currentValue === `undefined`)
         return undefined;
 
-      return applyValidator(key, currentValue, opts.validator);
+      return applyValidator(usedName ?? key, currentValue, opts.validator);
     },
   });
 }


### PR DESCRIPTION
As I may have mentioned before, I've got a CLI with options generated based on a JSON Schema. To ensure the names don't clash (e.g. if there's an option called `execute`) all option properties are prefixed with `option_`. Validation errors contain this option name, which is confusing.

Even without my weird naming, I would argue that showing the actually used option rather than the property name is more user friendly.

Before:

```
ai build all --unknown-target foo
Usage Error: Invalid option validation for option_unknownTarget: expected a valid enumeration value (got "foo")
```

After:

```
ai build all --unknown-target foo
Usage Error: Invalid option validation for --unknown-target: expected a valid enumeration value (got "foo")
```