### PR TITLE
feat: make validation error less confusing

### DIFF
--- a/sources/advanced/options/utils.ts
+++ b/sources/advanced/options/utils.ts
@@ -84,7 +84,7 @@ export function applyValidator<U, V>(name: string, value: U, validator?: StrictV
 
   const check = validator(value, {errors, coercions, coercion: v => { value = v; }});
   if (!check)
-    throw formatError(`Invalid option validation for ${name}`, errors);
+    throw formatError(`Invalid value for ${name}`, errors);
 
   for (const [, op] of coercions)
     op();


### PR DESCRIPTION
The current message reads "invalid option validation" which I personally interpret as "the validation is invalid" (i.e. a mistake of the CLI author) rather than "the value is invalid" (i.e. a mistake of the CLI user).

As a non-native English speaker this might just be me though.