### PR TITLE
feat: export ErrorMeta and create ErrorWithMeta

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -411,7 +411,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
       }
 
       result += `\n`;
-      result += formatMarkdownish(`You can also print more details about any of these commands by calling them after adding the \`-h,--help\` flag right after the command name.`, {format: this.format(colored), paragraphs: true});
+      result += formatMarkdownish(`You can also print more details about any of these commands by calling them with the \`-h,--help\` flag right after the command name.`, {format: this.format(colored), paragraphs: true});
     } else {
       if (!detailed) {
         const {usage} = this.getUsageByRegistration(commandClass);

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -2,6 +2,7 @@ import {Readable, Writable}                                     from 'stream';
 
 import {HELP_COMMAND_INDEX}                                     from '../constants';
 import {CliBuilder, CommandBuilder}                             from '../core';
+import {ErrorMeta}                                              from '../errors';
 import {formatMarkdownish, ColorFormat, richFormat, textFormat} from '../format';
 
 import {CommandClass, Command, Definition}                      from './Command';
@@ -491,8 +492,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
 
     result += `${this.format(colored).error(name)}: ${error.message}\n`;
 
-    // @ts-ignore
-    const meta = error.clipanion as core.ErrorMeta | undefined;
+    const meta = error.clipanion as ErrorMeta | undefined;
 
     if (typeof meta !== `undefined`) {
       if (meta.type === `usage`) {

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -3,7 +3,7 @@ export {Command} from './Command';
 export {BaseContext, Cli, CliOptions} from './Cli';
 export {CommandClass, Usage, Definition} from './Command';
 
-export {UsageError} from '../errors';
+export {UsageError, ErrorMeta, ErrorWithMeta} from '../errors';
 
 export * as Builtins from './builtins';
 export * as Option from './options';

--- a/sources/errors.ts
+++ b/sources/errors.ts
@@ -51,7 +51,7 @@ export class AmbiguousSyntaxError extends Error {
     super();
     this.name = `AmbiguousSyntaxError`;
 
-    this.message = `Cannot find who to pick amongst the following alternatives:\n\n${this.usages.map((usage, index) => {
+    this.message = `Cannot find which to pick amongst the following alternatives:\n\n${this.usages.map((usage, index) => {
       return `${`${index}.`.padStart(4)} ${usage}`;
     }).join(`\n`)}\n\n${whileRunning(input)}`;
   }

--- a/sources/errors.ts
+++ b/sources/errors.ts
@@ -7,6 +7,27 @@ export type ErrorMeta = {
 };
 
 /**
+ * An error with metadata telling clipanion how to print it
+ *
+ * Errors with this metadata property will have their name and message printed, but not the
+ * stacktrace.
+ *
+ * This should be used for errors where the message is the part that's important but the stacktrace is useless.
+ * Some examples of where this might be useful are:
+ *
+ * - Invalid input by the user (see `UsageError`)
+ * - A HTTP connection fails, the user is shown "Failed To Fetch Data: Could not ocnnect to server example.com" without stacktrace
+ * - A command in which the user enters credentials doesn't want to show a stacktract when the user enters invalid credentials
+ * - ...
+ */
+export interface ErrorWithMeta extends Error {
+  /**
+   * Metadata detailing how clipanion should print this error
+   */
+  readonly clipanion: ErrorMeta;
+}
+
+/**
  * A generic usage error with the name `UsageError`.
  *
  * It should be used over `Error` only when it's the user's fault.

--- a/sources/errors.ts
+++ b/sources/errors.ts
@@ -16,7 +16,7 @@ export type ErrorMeta = {
  * Some examples of where this might be useful are:
  *
  * - Invalid input by the user (see `UsageError`)
- * - A HTTP connection fails, the user is shown "Failed To Fetch Data: Could not ocnnect to server example.com" without stacktrace
+ * - A HTTP connection fails, the user is shown "Failed To Fetch Data: Could not connect to server example.com" without stacktrace
  * - A command in which the user enters credentials doesn't want to show a stacktract when the user enters invalid credentials
  * - ...
  */


### PR DESCRIPTION
This makes it possible for downstream projects to create their own errors with `ErrorMeta` with type safety.