### PR TITLE
docs: mention clipanion-v3-codemod in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Clipanion is used in [Yarn](https://github.com/yarnpkg/berry) with great success
 
 Check the website for our documentation: [mael.dev/clipanion](https://mael.dev/clipanion/).
 
+## Migration
+
+You can use [`clipanion-v3-codemod`](https://github.com/paul-soporan/clipanion-v3-codemod) to migrate a Clipanion v2 codebase to v3.
+
 ## Overview
 
 Commands are declared by extending from the `Command` abstract base class, and more specifically by implementing its `execute` method which will then be called by Clipanion. Whatever exit code it returns will then be set as the exit code for the process:


### PR DESCRIPTION
As discussed on Discord, I added a `Migration` section in the README, which mentions the codemod I wrote - `clipanion-v3-codemod`, which can migrate nearly all Clipanion v2 code to v3 (except schemas and multiple option decorators on the same class property, but it warns on those cases). It even supports the fallback syntax.

The codemod is also heavily tested and it can successfully migrate the entire Yarn codebase (tested on the commit before you migrated manually) except schemas and the case with multiple option decorators.