### PR TITLE
Fixes the types for Command.String

### DIFF
--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -64,10 +64,11 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
         currentValue = value;
       }
 
-      if (typeof initialValue === `undefined` && typeof currentValue === `undefined`)
-        return undefined;
-
-      return applyValidator(usedName ?? key, currentValue, opts.validator);
+      if (typeof currentValue === `string`) {
+        return applyValidator(usedName ?? key, currentValue, opts.validator);
+      } else {
+        return currentValue;
+      }
     },
   });
 }

--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -29,8 +29,8 @@ export type StringPositionalFlags<T> = {
 function StringOption<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
 function StringOption<T = string, Arity extends number = 1>(descriptor: string, opts: StringOptionNoBoolean<T, Arity> & {required: true}): CommandOptionReturn<WithArity<T, Arity>>;
 function StringOption<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
-function StringOption<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
-function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
+function StringOption<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
+function StringOption<T = string>(descriptor: string, initialValue: string | boolean, opts: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
 function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
 function StringOption<T = string, Arity extends number = 1>(descriptor: string, initialValueBase: StringOption<T> | WithArity<string, Arity> | string | boolean | undefined, optsBase?: StringOption<T>) {
   const [initialValue, opts] = rerouteArguments(initialValueBase, optsBase ?? {});
@@ -140,8 +140,8 @@ export function String<T = string>(opts: StringPositionalFlags<T>): CommandOptio
 export function String<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T> & {required: true}): CommandOptionReturn<T | boolean>;
 export function String<T = string, Arity extends number = 1>(descriptor: string, opts: StringOptionNoBoolean<T, Arity> & {required: true}): CommandOptionReturn<WithArity<T, Arity>>;
 export function String<T = string, Arity extends number = 1>(descriptor: string, opts?: StringOptionNoBoolean<T, Arity>): CommandOptionReturn<WithArity<T, Arity> | undefined>;
-export function String<T = string>(descriptor: string, opts?: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
-export function String<T = string>(descriptor: string, initialValue: string | boolean, opts?: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
+export function String<T = string>(descriptor: string, opts: StringOptionTolerateBoolean<T>): CommandOptionReturn<T | boolean | undefined>;
+export function String<T = string>(descriptor: string, initialValue: string | boolean, opts: Omit<StringOptionTolerateBoolean<T>, 'required'>): CommandOptionReturn<T | boolean>;
 export function String<T = string, Arity extends number = 1>(descriptor: string, initialValue: WithArity<string, Arity>, opts?: Omit<StringOptionNoBoolean<T, Arity>, 'required'>): CommandOptionReturn<WithArity<T, Arity>>;
 
 // This function is badly typed, but it doesn't matter because the overloads provide the true public typings

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -1027,4 +1027,33 @@ describe(`Advanced`, () => {
 
     await expect(runCli(cli, [`--foo`, `--bar`])).to.be.rejectedWith(`property "foo" forbids using property "bar"`);
   });
+
+  it(`should coerce options when requested`, async () => {
+    class FooCommand extends Command {
+      foo = Option.String(`--foo`, {validator: t.isNumber()});
+
+      async execute() {}
+    }
+
+    const cli = Cli.from([FooCommand]);
+
+    await expect(runCli(cli, [`--foo`, `42`])).to.eventually.equal(``);
+    await expect(runCli(cli, [`--foo`, `ab`])).to.be.rejectedWith(`Invalid value for --foo: expected a number`);
+  });
+
+  it.only(`should skip coercion for booleans`, async () => {
+    class FooCommand extends Command {
+      foo = Option.String(`--foo`, {validator: t.isNumber(), tolerateBoolean: true});
+      bar = Option.String(`--bar`, false, {validator: t.isNumber(), tolerateBoolean: true});
+
+      async execute() {
+        log(this, [`foo`, `bar`]);
+      }
+    }
+
+    const cli = Cli.from([FooCommand]);
+
+    await expect(runCli(cli, [`--foo=42`])).to.eventually.equal(`Running FooCommand\n42\nfalse\n`);
+    await expect(runCli(cli, [`--foo`])).to.eventually.equal(`Running FooCommand\ntrue\nfalse\n`);
+  });
 });

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -20,7 +20,7 @@ class MyCommand extends Command {
   booleanWithRequiredAndDefault = Option.Boolean(`--foo`, false, {required: true});
 
   string = Option.String(`--foo`);
-  stringWithDefault = Option.String(`--foo`, false);
+  stringWithDefault = Option.String(`--foo`, `foo`);
   stringWithValidator = Option.String(`--foo`, {validator: t.isNumber()});
   stringWithValidatorAndDefault = Option.String(`--foo`, `0`, {validator: t.isNumber()});
   stringWithValidatorAndRequired = Option.String(`--foo`, {validator: t.isNumber(), required: true});
@@ -79,8 +79,7 @@ class MyCommand extends Command {
     assertEqual<boolean>()(this.booleanWithRequired, true);
 
     assertEqual<string | undefined>()(this.string, true);
-    assertEqual<string | boolean>()(this.stringWithDefault, true);
-    assertEqual<string | boolean>()(this.stringWithDefault, true);
+    assertEqual<string>()(this.stringWithDefault, true);
     assertEqual<number | undefined>()(this.stringWithValidator, true);
     assertEqual<number>()(this.stringWithValidatorAndRequired, true);
     assertEqual<number>()(this.stringWithValidatorAndDefault, true);

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -44,6 +44,7 @@ class MyCommand extends Command {
   stringWithTolerateBoolean = Option.String(`--foo`, {tolerateBoolean: true});
   stringWithTolerateBooleanAndRequired = Option.String(`--foo`, {tolerateBoolean: true, required: true});
   stringWithTolerateBooleanAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true});
+  stringWithTolerateBooleanAndValidator = Option.String(`--foo`, false, {tolerateBoolean: true, validator: t.isNumber()});
   // @ts-expect-error: Overload prevents this
   stringWithTolerateBooleanAndRequiredAndDefault = Option.String(`--foo`, false, {tolerateBoolean: true, required: true});
 


### PR DESCRIPTION
It seems 37ccb64eacc636182ca4daa972bbc1ad56bc38a8 introduced a little bug where the following:

```
opt = Option.String(`--foo`, `bar`);
```

Caused `opt` to be inferred as `string | boolean`. I believe this is due to the `tolerateBoolean` options being incorrectly set as optional in their alternatives, when they should instead be required (since otherwise TS will interpret the lack of options as tolerating boolean, which isn't the intended default behaviour).

I also fixed the interaction of `tolerateBoolean` w/ validators, since the validators probably shouldn't run on those values.

cc @paul-soporan 