### PR TITLE
perf(core): skip unnecessary debug iterations

### DIFF
--- a/sources/core.ts
+++ b/sources/core.ts
@@ -134,9 +134,12 @@ export function simplifyMachine(input: StateMachine) {
 }
 
 export function debugMachine(machine: StateMachine, {prefix = ``}: {prefix?: string} = {}) {
-  debug(`${prefix}Nodes are:`);
-  for (let t = 0; t < machine.nodes.length; ++t) {
-    debug(`${prefix}  ${t}: ${JSON.stringify(machine.nodes[t])}`);
+  // Don't iterate unless it's needed
+  if (DEBUG) {
+    debug(`${prefix}Nodes are:`);
+    for (let t = 0; t < machine.nodes.length; ++t) {
+      debug(`${prefix}  ${t}: ${JSON.stringify(machine.nodes[t])}`);
+    }
   }
 }
 


### PR DESCRIPTION
`debugMachine` was doing unnecessary iterations because the `if (DEBUG)` check only existed in the `debug` function which was called inside the for loop (which meant that the iterations didn't do anything).

Saves 28.1 ms when running any yarn command.

![image](https://user-images.githubusercontent.com/32596136/108089997-d5cd6800-7082-11eb-9416-7b546a10e167.png)
