### PR TITLE
fix: Coerce positionals if validator is supplied

### DIFF
--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -108,7 +108,7 @@ function StringPositional<T = string>(opts: StringPositionalFlags<T> = {}) {
         // We remove the positional from the list
         const [positional] = state.positionals.splice(i, 1);
 
-        return positional.value;
+        return applyValidator(opts.name ?? key, positional.value, opts.validator);
       }
 
       return undefined;

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -1033,12 +1033,14 @@ describe(`Advanced`, () => {
     class FooCommand extends Command {
       foo = Option.String(`--foo`, {validator: t.isNumber()});
 
-      async execute() {}
+      async execute() {
+        log(this, [`foo`]);
+      }
     }
 
     const cli = Cli.from([FooCommand]);
 
-    await expect(runCli(cli, [`--foo`, `42`])).to.eventually.equal(``);
+    await expect(runCli(cli, [`--foo`, `42`])).to.eventually.equal(`Running FooCommand\n42\n`);
     await expect(runCli(cli, [`--foo`, `ab`])).to.be.rejectedWith(`Invalid value for --foo: expected a number`);
   });
 
@@ -1046,12 +1048,14 @@ describe(`Advanced`, () => {
     class FooCommand extends Command {
       foo = Option.String({validator: t.isNumber()});
 
-      async execute() {}
+      async execute() {
+        log(this, [`foo`]);
+      }
     }
 
     const cli = Cli.from([FooCommand]);
 
-    await expect(runCli(cli, [`42`])).to.eventually.equal(``);
+    await expect(runCli(cli, [`42`])).to.eventually.equal(`Running FooCommand\n42\n`);
     await expect(runCli(cli, [`ab`])).to.be.rejectedWith(`Invalid value for foo: expected a number`);
   });
 

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -1042,6 +1042,19 @@ describe(`Advanced`, () => {
     await expect(runCli(cli, [`--foo`, `ab`])).to.be.rejectedWith(`Invalid value for --foo: expected a number`);
   });
 
+  it(`should coerce positionals when requested`, async () => {
+    class FooCommand extends Command {
+      foo = Option.String({validator: t.isNumber()});
+
+      async execute() {}
+    }
+
+    const cli = Cli.from([FooCommand]);
+
+    await expect(runCli(cli, [`42`])).to.eventually.equal(``);
+    await expect(runCli(cli, [`ab`])).to.be.rejectedWith(`Invalid value for foo: expected a number`);
+  });
+
   it(`should skip coercion for booleans`, async () => {
     class FooCommand extends Command {
       foo = Option.String(`--foo`, {validator: t.isNumber(), tolerateBoolean: true});


### PR DESCRIPTION
Hi,
I noticed validators weren't being applied to positional arguments; this PR is to fix that issue and add a corresponding test case.