### PR TITLE
fix: Fix type inference for explicitly required positionals.

### DIFF
--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -74,9 +74,8 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
 }
 
 function StringPositional(): CommandOptionReturn<string>;
-function StringPositional<T = string>(opts: Omit<StringPositionalFlags<T>, 'required'>): CommandOptionReturn<T>;
 function StringPositional<T = string>(opts: StringPositionalFlags<T> & {required: false}): CommandOptionReturn<T | undefined>;
-function StringPositional<T = string>(opts: StringPositionalFlags<T>): CommandOptionReturn<T | undefined>;
+function StringPositional<T = string>(opts: StringPositionalFlags<T>): CommandOptionReturn<T>;
 function StringPositional<T = string>(opts: StringPositionalFlags<T> = {}) {
   const {required = true} = opts;
 
@@ -126,9 +125,8 @@ function StringPositional<T = string>(opts: StringPositionalFlags<T> = {}) {
  * command line.
  */
 export function String(): CommandOptionReturn<string>;
-export function String<T = string>(opts: Omit<StringPositionalFlags<T>, 'required'>): CommandOptionReturn<T>;
 export function String<T = string>(opts: StringPositionalFlags<T> & {required: false}): CommandOptionReturn<T | undefined>;
-export function String<T = string>(opts: StringPositionalFlags<T>): CommandOptionReturn<T | undefined>;
+export function String<T = string>(opts: StringPositionalFlags<T>): CommandOptionReturn<T>;
 
 /**
  * Used to annotate string options. Such options will be typed as strings

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -10,7 +10,8 @@ function assertEqual<U>() {
 }
 
 class MyCommand extends Command {
-  requiredPositional = Option.String();
+  defaultPositional = Option.String();
+  requiredPositional = Option.String({required: true});
   optionalPositional = Option.String({required: false});
 
   boolean = Option.Boolean(`--foo`);
@@ -72,6 +73,7 @@ class MyCommand extends Command {
   proxy = Option.Proxy();
 
   async execute() {
+    assertEqual<string>()(this.defaultPositional, true);
     assertEqual<string>()(this.requiredPositional, true);
     assertEqual<string | undefined>()(this.optionalPositional, true);
 


### PR DESCRIPTION
Hi,
The type definitions are giving the wrong type for positional arguments specified with `{ required: true }`:
![required-positional-types](https://user-images.githubusercontent.com/20180702/111024572-97358e00-8433-11eb-8468-3e63ab1643df.png)

Not sure if there's a preferred way to do the definitions but this PR is my attempt + updated inference tests.