### PR TITLE
Add documentation for help

### DIFF
--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -7,23 +7,36 @@ Clipanion includes tools to allow documenting and adding a help functionality ea
 
 ## The `usage` member
 
-Commands have a `usage` static member that documents the command.
-It contains a category, to group similar commands, a small and log description, and examples.
-Unless a usage has been specified, the command is considered hidden and not shown to users.
+Commands may define a `usage` static property that will be used to document the command. It must be an object with any of the following fields:
+
+- `category` will be used to group commands in the global help listing
+- `description` is a one-line description used in the global help listing
+- `details` is a large description of your command, with paragraphs separated with `\n\n`
+- `examples` is an array of `[description, command]` tuple
+
+Note that commands are hidden from the global help listing by default unless a `usage` property has been specified.
 
 ```ts
-import { Cli, Command, Option } from "clipanion";
+import {Cli, Command, Option} from "clipanion";
 
 export class HelloCommand extends Command {
-  static paths = [[`my-command`]];
+  static paths = [
+    [`my-command`],
+  ];
+
   static usage = {
     category: `My category`,
     description: `A small description of the command.`,
-    details: `A longer description of the command.`,
-    examples: [
-      [`A basic example`, `$0 my-command`],
-      [`A second example`, `$0 my-command --with-parameter`],
-    ],
+    details: `
+      A longer description of the command.
+    `,
+    examples: [[
+      `A basic example`,
+      `$0 my-command`,
+    ], [
+      `A second example`,
+      `$0 my-command --with-parameter`,
+    ]],
   };
 
   p = Option.Boolean(`--with-parameter`);
@@ -36,58 +49,55 @@ export class HelloCommand extends Command {
 }
 ```
 
-## The help command
+```
+$ my-app my-command -h
+```
 
-The builtin help command allows to get help about any documented command. To add it, simply import and register it.
+```
+━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+$ my-app my-command [--with-parameter]
+
+━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+A longer description of the command.
+
+━━━ Examples ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+A basic example
+  $ my-app my-command
+
+A second example
+  $ my-app my-command --with-parameter
+```
+
+## The `help` command
+
+The builtin `help` command prints the list of available commands. To add it, simply import and register it:
 
 ```ts
-import { Cli, Builtins } from "clipanion";
+import {Cli, Builtins} from "clipanion";
 
 const cli = new Cli({
-  binaryName: "my-app",
-  binaryLabel: "My Application",
+  binaryName: `my-app`,
+  binaryLabel: `My Application`,
   binaryVersion: `1.0.0`,
-}
 });
+
 cli.register(Builtins.HelpCommand);
 ```
 
-:::danger
-Be careful when adding this command, it will conflict with any command that has a `-h` or `--help` flag and make it throw an `AmbiguousSyntaxError`!
-:::
-
-Now, appending the flag `-h` or `--help` to a command with the `usage` property defined will show its documentation:
-
 ```
-my-app my-command -h
-    => ━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-       $ my-app my-command [--with-parameter]
-
-       ━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-       A longer description of the command.
-
-       ━━━ Examples ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-       A basic example
-         $ my-app my-command
-
-       A second example
-         $ my-app my-command --with-parameter
+$ my-app help
 ```
 
-Those documented commands will also show up on the global help:
-
 ```
-my-app -h
-    => ━━━ My Application - 1.0.0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━ My Application - 1.0.0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-         $ my-app <command>
+$ my-app <command>
 
-       ━━━ My category ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━ My category ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-         my-app my-command [--with-parameter]
-           A small description of the command.
-
+my-app my-command [--with-parameter]
+  A small description of the command.
 ```

--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -5,16 +5,16 @@ title: Help command
 
 Clipanion includes tools to allow documenting and adding a help functionality easily.
 
-## The `usage` member
+## The `usage` property
 
-Commands may define a `usage` static property that will be used to document the command. It must be an object with any of the following fields:
+Commands may define a `usage` static property that will be used to document the command. If defined, it must be an object with any of the following fields:
 
 - `category` will be used to group commands in the global help listing
 - `description` is a one-line description used in the global help listing
 - `details` is a large description of your command, with paragraphs separated with `\n\n`
 - `examples` is an array of `[description, command]` tuple
 
-Note that commands are hidden from the global help listing by default unless a `usage` property has been specified.
+Note that all commands are hidden from the global help listing by default unless they define a `usage` property.
 
 ```ts
 import {Cli, Command, Option} from "clipanion";
@@ -28,7 +28,9 @@ export class HelloCommand extends Command {
     category: `My category`,
     description: `A small description of the command.`,
     details: `
-      A longer description of the command.
+      A longer description of the command with some \`markdown code\`.
+      
+      Multiple paragraphs are allowed. Clipanion will take care of both reindenting the content and wrapping the paragraphs as needed.
     `,
     examples: [[
       `A basic example`,
@@ -60,7 +62,10 @@ $ my-app my-command [--with-parameter]
 
 ━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-A longer description of the command.
+A longer description of the command with some \`markdown code\`.
+
+Multiple paragraphs are allowed. Clipanion will take care of both reindenting the
+content and wrapping the paragraphs as needed.
 
 ━━━ Examples ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -1,0 +1,93 @@
+---
+id: help
+title: Help command
+---
+
+Clipanion includes tools to allow documenting and adding a help functionality easily.
+
+## The `usage` member
+
+Commands have a `usage` static member that documents the command.
+It contains a category, to group similar commands, a small and log description, and examples.
+Unless a usage has been specified, the command is considered hidden and not shown to users.
+
+```ts
+import { Cli, Command, Option } from "clipanion";
+
+export class HelloCommand extends Command {
+  static paths = [[`my-command`]];
+  static usage = {
+    category: `My category`,
+    description: `A small description of the command.`,
+    details: `A longer description of the command.`,
+    examples: [
+      [`A basic example`, `$0 my-command`],
+      [`A second example`, `$0 my-command --with-parameter`],
+    ],
+  };
+
+  p = Option.Boolean(`--with-parameter`);
+
+  async execute() {
+    this.context.stdout.write(
+      this.p ? `Called with parameter` : `Called without parameter`
+    );
+  }
+}
+```
+
+## The help command
+
+The builtin help command allows to get help about any documented command. To add it, simply import and register it.
+
+```ts
+import { Cli, Builtins } from "clipanion";
+
+const cli = new Cli({
+  binaryName: "my-app",
+  binaryLabel: "My Application",
+  binaryVersion: `1.0.0`,
+}
+});
+cli.register(Builtins.HelpCommand);
+```
+
+:::danger
+Be careful when adding this command, it will conflict with any command that has a `-h` or `--help` flag and make it throw an `AmbiguousSyntaxError`!
+:::
+
+Now, appending the flag `-h` or `--help` to a command with the `usage` property defined will show its documentation:
+
+```
+my-app my-command -h
+    => ━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+       $ my-app my-command [--with-parameter]
+
+       ━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+       A longer description of the command.
+
+       ━━━ Examples ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+       A basic example
+         $ my-app my-command
+
+       A second example
+         $ my-app my-command --with-parameter
+```
+
+Those documented commands will also show up on the global help:
+
+```
+my-app -h
+    => ━━━ My Application - 1.0.0 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+         $ my-app <command>
+
+       ━━━ My category ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+         my-app my-command [--with-parameter]
+           A small description of the command.
+
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
   someSidebar: {
-    General: [`overview`, `getting-started`, `paths`, `options`, `contexts`, `validation`, `tips`],
+    General: [`overview`, `getting-started`, `paths`, `options`, `contexts`, `validation`, `help`, `tips`],
     API: [`api/cli`, `api/builtins`, `api/option`],
   },
 };


### PR DESCRIPTION
Hello 👋 !
This is my first contribution here and I hope I haven't done anything wrong. 
I couldn't find any autoformat script so I just used prettier with default settings for the snippets.

This PR adds a documentation page about the `usage` member and help builtin command. I think it is useful because I couldn't understand the help command until I found the `Usage` type in the typescript definitions, which is maybe a bit too "hidden" for the average user. English is not my mother tongue so please check for typos/style errors before merging 😓.