### PR TITLE
Make it easier for `Cli` subclasses to override methods

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -149,7 +149,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
 
   private readonly builder: CliBuilder<CliContext<Context>>;
 
-  private readonly registrations: Map<CommandClass<Context>, {
+  protected readonly registrations: Map<CommandClass<Context>, {
     index: number,
     builder: CommandBuilder<CliContext<Context>>,
     specs: Map<string, CommandOption<unknown>>,
@@ -512,7 +512,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
     return result;
   }
 
-  private getUsageByRegistration(klass: CommandClass<Context>, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
+  protected getUsageByRegistration(klass: CommandClass<Context>, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
     const record = this.registrations.get(klass);
     if (typeof record === `undefined`)
       throw new Error(`Assertion failed: Unregistered command`);
@@ -520,11 +520,11 @@ export class Cli<Context extends BaseContext = BaseContext> implements MiniCli<C
     return this.getUsageByIndex(record.index, opts);
   }
 
-  private getUsageByIndex(n: number, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
+  protected getUsageByIndex(n: number, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
     return this.builder.getBuilderByIndex(n).usage(opts);
   }
 
-  private format(colored: boolean = this.enableColors): ColorFormat {
+  protected format(colored: boolean = this.enableColors): ColorFormat {
     return colored ? richFormat : textFormat;
   }
 }


### PR DESCRIPTION
This changes the privacy modifiers for several methods and fields in the `Cli` class to make it easier/cleaner to re-use and override them in subclasses.

The use case that I'm trying to solve is to be able to customize how the help text is formatted and what information is displayed in it. At the moment this involves fighting/suppressing TypeScript warnings in several places.