### PR TITLE
Make Type Check In `validateAndExecute()` Stricter

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -152,7 +152,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
     const commandClass = this.constructor as CommandClass<Context>;
     const cascade = commandClass.schema;
 
-    if (typeof cascade !== `undefined`) {
+    if (Array.isArray(cascade)) {
       const {isDict, isUnknown, applyCascade} = await import(`typanion`);
       const schema = applyCascade(isDict(isUnknown()), cascade);
 
@@ -166,6 +166,8 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
       for (const [, op] of coercions) {
         op();
       }
+    } else if (cascade != null) {
+      throw new Error(`Invalid command schema`);
     }
 
     const exitCode = await this.execute();


### PR DESCRIPTION
We were seeing an issue in yarn v3.0.2 when using the workspaces plugin
where it was possible for a command's `schema` prop to be not
`undefined`, but also not an array. The issue is captured in the yarn
repository here: https://github.com/yarnpkg/berry/issues/3108

In order to ensure that `applyCascade()` is only called with valid
arguments, rather than checking that `cascade` is not `undefined`,
ensure that it is an `Array`. Otherwise, when we try to iterate over it,
we get a Type Error stating that `followups.every()` is not a function.