### PR TITLE
Implements stream capture

### DIFF
--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -308,6 +308,7 @@ describe(`Advanced`, () => {
       binaryLabel: `My CLI`,
       binaryName: `my-cli`,
       binaryVersion: `1.0.0`,
+      enableCapture: false,
       enableColors: false,
     };
 
@@ -1172,5 +1173,29 @@ describe(`Advanced`, () => {
 
     await expect(runCli(cli, [`--foo=42`])).to.eventually.equal(`Running FooCommand\n42\nfalse\n`);
     await expect(runCli(cli, [`--foo`])).to.eventually.equal(`Running FooCommand\ntrue\nfalse\n`);
+  });
+
+  it(`should capture stdout if requested`, async () => {
+    class FooCommand extends Command {
+      async execute() {
+        console.log(`foo`);
+      }
+    }
+
+    const cli = Cli.from([FooCommand], {enableCapture: true});
+
+    await expect(runCli(cli, [])).to.eventually.equal(`foo\n`);
+  });
+
+  it(`should capture stderr if requested`, async () => {
+    class FooCommand extends Command {
+      async execute() {
+        console.error(`foo`);
+      }
+    }
+
+    const cli = Cli.from([FooCommand], {enableCapture: true});
+
+    await expect(runCli(cli, [])).to.eventually.equal(`foo\n`);
   });
 });


### PR DESCRIPTION
It may sound a little weird to have to use `this.context.stdout.write` to write to the console in a Node context (developers are used to just call `console.log` for that). While it's important to keep this distinction in order to let commands be chainable (ie one command may call others and capture their output), newest Node releases may provide us an interesting tool to improve the user experience.

This diff introduces a new option, `enableCapture`. When set (the default is `false` at the moment), passing non-standard streams to a CLI execution will cause Clipanion to register itself into the `process.stdout.write` pipeline (same for stderr), effectively capturing everything that JS code would print. Asynchronicity shouldn't be an issue thanks to [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#async_context_class_asynclocalstorage), which will ensure that each command access their own streams, even if asynchronous.