### PR TITLE
[doc] help.md: wrap "usage" with "Command.Usage()"

### DIFF
--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -24,7 +24,7 @@ export class HelloCommand extends Command {
     [`my-command`],
   ];
 
-  static usage = {
+  static usage = Command.Usage({
     category: `My category`,
     description: `A small description of the command.`,
     details: `
@@ -39,7 +39,7 @@ export class HelloCommand extends Command {
       `A second example`,
       `$0 my-command --with-parameter`,
     ]],
-  };
+  });
 
   p = Option.Boolean(`--with-parameter`);
 


### PR DESCRIPTION
Without this, TypeScript compiler may wrongly infer the type of the passed literal and complain that
`examples` is not array of string tuples, but two-dimensional string array.