### PR TITLE
feat: export cli.format and formatMarkdownish

### DIFF
--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -121,6 +121,13 @@ export type MiniCli<Context extends BaseContext> = CliOptions & {
   error(error: Error, opts?: {command?: Command<Context> | null}): string;
 
   /**
+   * Returns a rich color format if colors are enabled, or a plain text format otherwise.
+   *
+   * @param colored Forcefully enable or disable colors.
+   */
+  format(colored?: boolean): ColorFormat;
+
+  /**
    * Compiles a command and its arguments using the `CommandBuilder`.
    *
    * @param input An array containing the name of the command and its arguments
@@ -321,6 +328,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
       enableColors: this.enableColors,
       definitions: () => this.definitions(),
       error: (error, opts) => this.error(error, opts),
+      format: colored => this.format(colored),
       process: input => this.process(input),
       run: (input, subContext?) => this.run(input, {...context, ...subContext} as Context),
       usage: (command, opts) => this.usage(command, opts),
@@ -591,6 +599,10 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
     return result;
   }
 
+  format(colored?: boolean): ColorFormat {
+    return colored ?? this.enableColors ?? Cli.defaultContext.colorDepth > 1 ? richFormat : textFormat;
+  }
+
   protected getUsageByRegistration(klass: CommandClass<Context>, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
     const record = this.registrations.get(klass);
     if (typeof record === `undefined`)
@@ -601,10 +613,6 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
 
   protected getUsageByIndex(n: number, opts?: {detailed?: boolean; inlineOptions?: boolean}) {
     return this.builder.getBuilderByIndex(n).usage(opts);
-  }
-
-  protected format(colored: boolean | undefined): ColorFormat {
-    return colored ?? this.enableColors ?? Cli.defaultContext.colorDepth > 1 ? richFormat : textFormat;
   }
 }
 

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -4,6 +4,7 @@ export {BaseContext, Cli, RunContext, CliOptions} from './Cli';
 export {CommandClass, Usage, Definition} from './Command';
 
 export {UsageError, ErrorMeta, ErrorWithMeta} from '../errors';
+export {formatMarkdownish, ColorFormat} from '../format';
 
 export * as Builtins from './builtins';
 export * as Option from './options';

--- a/sources/format.ts
+++ b/sources/format.ts
@@ -35,6 +35,13 @@ function dedent(text: string) {
     .join(`\n`);
 }
 
+/**
+ * Formats markdown text to be displayed to the console. Not all markdown features are supported.
+ *
+ * @param text The markdown text to format.
+ * @param opts.format The format to use.
+ * @param opts.paragraphs Whether to cut the text into paragraphs of 80 characters at most.
+ */
 export function formatMarkdownish(text: string, {format, paragraphs}: {format: ColorFormat, paragraphs: boolean}) {
   // Enforce \n as newline character
   text = text.replace(/\r\n?/g, `\n`);
@@ -74,7 +81,7 @@ export function formatMarkdownish(text: string, {format, paragraphs}: {format: C
     return format.code($1 + $2 + $1);
   });
 
-  // Highlight the code segments
+  // Highlight the bold segments
   text = text.replace(/(\*\*)((?:.|[\n])*?)\1/g, ($0, $1, $2) => {
     return format.bold($1 + $2 + $1);
   });


### PR DESCRIPTION
- `cli.format` wasn't exported on the `MiniCli`
- `formatMarkdownish` wasn't exported from the entry point
- I need to use them in Yarn