### PR TITLE
Fix main field to be compatible with nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "demo": "node --require ts-node/register sources/demos/advanced.ts"
   },
   "publishConfig": {
-    "main": "lib/advanced/index"
+    "main": "lib/advanced/index.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/46770#issuecomment-966612103 for detail, in `nodenext` module resolution it requires a full filename including extension