### PR TITLE
fix: Fixed markdownish text missing spaces.

### DIFF
--- a/sources/format.ts
+++ b/sources/format.ts
@@ -56,7 +56,7 @@ export function formatMarkdownish(text: string, {format, paragraphs}: {format: C
   text = text.replace(/^(\s*)-([^\n]*?)\n+/gm, `$1-$2\n\n`);
 
   // Single newlines are removed; larger than that are collapsed into one
-  text = text.replace(/\n(\n)?\n*/g, `$1`);
+  text = text.replace(/\n(\n)?\n*/g, ` $1`);
 
   if (paragraphs) {
     text = text.split(/\n/).map(paragraph => {

--- a/sources/format.ts
+++ b/sources/format.ts
@@ -56,7 +56,7 @@ export function formatMarkdownish(text: string, {format, paragraphs}: {format: C
   text = text.replace(/^(\s*)-([^\n]*?)\n+/gm, `$1-$2\n\n`);
 
   // Single newlines are removed; larger than that are collapsed into one
-  text = text.replace(/\n(\n)?\n*/g, ` $1`);
+  text = text.replace(/\n(\n)?\n*/g, ($0, $1) => $1 ? $1 : ` `);
 
   if (paragraphs) {
     text = text.split(/\n/).map(paragraph => {


### PR DESCRIPTION
Hi,

Just a quick one; I noticed detailed descriptions with multiple lines are missing spaces between some words after they get unwrapped by `formatMarkdownish`:
```ts
class TestCommand extends Command {
  static usage = Command.Usage({
    description: 'Test command.',
    details: `
      This is the detailed description. As
      part of the process of formatting it
      for display, single newlines will be
      replaced with spaces.

      Multiple newlines are interpreted as
      a paragraph break, and replaced with
      a single newline.`
  })
  async execute () {}
}
```
Currently produces this:
``` 
$ yarn ts-node test.ts --help
Test command.

━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

$ ...

━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

This is the detailed description. Aspart of the process of formatting itfor 
display, single newlines will bereplaced with spaces.

Multiple newlines are interpreted asa paragraph break, and replaced witha single 
newline.
```

After fixing, produces this:
```
$ yarn ts-node test.ts --help
Test command.

━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

$ ...

━━━ Details ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

This is the detailed description. As part of the process of formatting it for 
display, single newlines will be replaced with spaces. 

Multiple newlines are interpreted as a paragraph break, and replaced with a 
single newline.
```

Fixes #98 