### PR TITLE
Implements `runExit`

### DIFF
--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);
+
+const moduleWrapper = tsserver => {
+  if (!process.versions.pnp) {
+    return tsserver;
+  }
+
+  const {isAbsolute} = require(`path`);
+  const pnpApi = require(`pnpapi`);
+
+  const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
+
+  const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
+    return `${locator.name}@${locator.reference}`;
+  }));
+
+  // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
+  // doesn't understand. This layer makes sure to remove the protocol
+  // before forwarding it to TS, and to add it back on all returned paths.
+
+  function toEditorPath(str) {
+    // We add the `zip:` prefix to both `.zip/` paths and virtual paths
+    if (isAbsolute(str) && !str.match(/^\^?(zip:|\/zip\/)/) && (str.match(/\.zip\//) || isVirtual(str))) {
+      // We also take the opportunity to turn virtual paths into physical ones;
+      // this makes it much easier to work with workspaces that list peer
+      // dependencies, since otherwise Ctrl+Click would bring us to the virtual
+      // file instances instead of the real ones.
+      //
+      // We only do this to modules owned by the the dependency tree roots.
+      // This avoids breaking the resolution when jumping inside a vendor
+      // with peer dep (otherwise jumping into react-dom would show resolution
+      // errors on react).
+      //
+      const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
+      if (resolved) {
+        const locator = pnpApi.findPackageLocator(resolved);
+        if (locator && dependencyTreeRoots.has(`${locator.name}@${locator.reference}`)) {
+          str = resolved;
+        }
+      }
+
+      str = normalize(str);
+
+      if (str.match(/\.zip\//)) {
+        switch (hostInfo) {
+          // Absolute VSCode `Uri.fsPath`s need to start with a slash.
+          // VSCode only adds it automatically for supported schemes,
+          // so we have to do it manually for the `zip` scheme.
+          // The path needs to start with a caret otherwise VSCode doesn't handle the protocol
+          //
+          // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
+          //
+          // Update Oct 8 2021: VSCode changed their format in 1.61.
+          // Before | ^zip:/c:/foo/bar.zip/package.json
+          // After  | ^/zip//c:/foo/bar.zip/package.json
+          //
+          case `vscode <1.61`: {
+            str = `^zip:${str}`;
+          } break;
+
+          case `vscode`: {
+            str = `^/zip/${str}`;
+          } break;
+
+          // To make "go to definition" work,
+          // We have to resolve the actual file system path from virtual path
+          // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
+          case `coc-nvim`: {
+            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+            str = resolve(`zipfile:${str}`);
+          } break;
+
+          // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
+          // We have to resolve the actual file system path from virtual path,
+          // everything else is up to neovim
+          case `neovim`: {
+            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+            str = `zipfile:${str}`;
+          } break;
+
+          default: {
+            str = `zip:${str}`;
+          } break;
+        }
+      }
+    }
+
+    return str;
+  }
+
+  function fromEditorPath(str) {
+    switch (hostInfo) {
+      case `coc-nvim`:
+      case `neovim`: {
+        str = str.replace(/\.zip::/, `.zip/`);
+        // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+        // So in order to convert it back, we use .* to match all the thing
+        // before `zipfile:`
+        return process.platform === `win32`
+          ? str.replace(/^.*zipfile:\//, ``)
+          : str.replace(/^.*zipfile:/, ``);
+      } break;
+
+      case `vscode`:
+      default: {
+        return process.platform === `win32`
+          ? str.replace(/^\^?(zip:|\/zip)\/+/, ``)
+          : str.replace(/^\^?(zip:|\/zip)\/+/, `/`);
+      } break;
+    }
+  }
+
+  // Force enable 'allowLocalPluginLoads'
+  // TypeScript tries to resolve plugins using a path relative to itself
+  // which doesn't work when using the global cache
+  // https://github.com/microsoft/TypeScript/blob/1b57a0395e0bff191581c9606aab92832001de62/src/server/project.ts#L2238
+  // VSCode doesn't want to enable 'allowLocalPluginLoads' due to security concerns but
+  // TypeScript already does local loads and if this code is running the user trusts the workspace
+  // https://github.com/microsoft/vscode/issues/45856
+  const ConfiguredProject = tsserver.server.ConfiguredProject;
+  const {enablePluginsWithOptions: originalEnablePluginsWithOptions} = ConfiguredProject.prototype;
+  ConfiguredProject.prototype.enablePluginsWithOptions = function() {
+    this.projectService.allowLocalPluginLoads = true;
+    return originalEnablePluginsWithOptions.apply(this, arguments);
+  };
+
+  // And here is the point where we hijack the VSCode <-> TS communications
+  // by adding ourselves in the middle. We locate everything that looks
+  // like an absolute path of ours and normalize it.
+
+  const Session = tsserver.server.Session;
+  const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
+  let hostInfo = `unknown`;
+
+  Object.assign(Session.prototype, {
+    onMessage(/** @type {string | object} */ message) {
+      const isStringMessage = typeof message === 'string';
+      const parsedMessage = isStringMessage ? JSON.parse(message) : message;
+
+      if (
+        parsedMessage != null &&
+        typeof parsedMessage === `object` &&
+        parsedMessage.arguments &&
+        typeof parsedMessage.arguments.hostInfo === `string`
+      ) {
+        hostInfo = parsedMessage.arguments.hostInfo;
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
+          hostInfo += ` <1.61`;
+        }
+      }
+
+      const processedMessageJSON = JSON.stringify(parsedMessage, (key, value) => {
+        return typeof value === 'string' ? fromEditorPath(value) : value;
+      });
+
+      return originalOnMessage.call(
+        this,
+        isStringMessage ? processedMessageJSON : JSON.parse(processedMessageJSON)
+      );
+    },
+
+    send(/** @type {any} */ msg) {
+      return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
+        return typeof value === `string` ? toEditorPath(value) : value;
+      })));
+    }
+  });
+
+  return tsserver;
+};
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require typescript/lib/tsserverlibrary.js
+    require(absPnpApiPath).setup();
+  }
+}
+
+// Defer to the real typescript/lib/tsserverlibrary.js your application uses
+module.exports = moduleWrapper(absRequire(`typescript/lib/tsserverlibrary.js`));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
   "name": "clipanion",
   "description": "Type-safe CLI library / framework with no runtime dependencies",
-  "keywords": ["cli", "typescript", "parser", "parsing", "argument", "args", "option", "command"],
+  "keywords": [
+    "cli",
+    "typescript",
+    "parser",
+    "parsing",
+    "argument",
+    "args",
+    "option",
+    "command"
+  ],
   "version": "3.2.0-rc.6",
   "main": "sources/advanced/index.ts",
   "license": "MIT",

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -177,6 +177,111 @@ function getDefaultColorDepth() {
   return 1;
 }
 
+export async function runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>): Promise<void>;
+export async function runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<void>;
+
+export async function runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>): Promise<void>;
+export async function runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<void>;
+
+export async function runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<void>;
+export async function runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<void>;
+
+export async function runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<void>;
+export async function runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<void>;
+
+export async function runExit(...args: Array<any>) {
+  const {
+    resolvedOptions,
+    resolvedCommandClasses,
+    resolvedArgv,
+    resolvedContext,
+  } = resolveRunParameters(args);
+
+  const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
+  return cli.runExit(resolvedArgv, resolvedContext);
+}
+
+export async function run<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>): Promise<number>;
+export async function run<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<number>;
+
+export async function run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>): Promise<number>;
+export async function run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<number>;
+
+export async function run<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<number>;
+export async function run<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<number>;
+
+export async function run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<number>;
+export async function run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<number>;
+
+export async function run(...args: Array<any>) {
+  const {
+    resolvedOptions,
+    resolvedCommandClasses,
+    resolvedArgv,
+    resolvedContext,
+  } = resolveRunParameters(args);
+
+  const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
+  return cli.run(resolvedArgv, resolvedContext);
+}
+
+function resolveRunParameters(args: Array<any>) {
+  let resolvedOptions: any;
+  let resolvedCommandClasses: any;
+  let resolvedArgv: any;
+  let resolvedContext: any;
+
+  switch (args.length) {
+    case 1: {
+      resolvedCommandClasses = args[0];
+    } break;
+
+    case 2: {
+      if (args[0] && (args[0].prototype instanceof Command) || Array.isArray(args[0])) {
+        resolvedCommandClasses = args[0];
+        if (Array.isArray(args[1])) {
+          resolvedArgv = args[1];
+        } else {
+          resolvedContext = args[1];
+        }
+      } else {
+        resolvedOptions = args[0];
+        resolvedCommandClasses = args[1];
+      }
+    } break;
+
+    case 3: {
+      if (Array.isArray(args[2])) {
+        resolvedOptions = args[0];
+        resolvedCommandClasses = args[1];
+        resolvedArgv = args[2];
+      } else if (args[1] && (args[1].prototype instanceof Command) || Array.isArray(args[1])) {
+        resolvedOptions = args[0];
+        resolvedCommandClasses = args[1];
+        resolvedContext = args[2];
+      } else {
+        resolvedCommandClasses = args[0];
+        resolvedArgv = args[1];
+        resolvedContext = args[2];
+      }
+    } break;
+
+    default: {
+      resolvedOptions = args[0];
+      resolvedCommandClasses = args[1];
+      resolvedArgv = args[2];
+      resolvedContext = args[3];
+    } break;
+  }
+
+  return {
+    resolvedOptions,
+    resolvedCommandClasses,
+    resolvedArgv,
+    resolvedContext,
+  };
+}
+
 /**
  * @template Context The context shared by all commands. Contexts are a set of values, defined when calling the `run`/`runExit` functions from the CLI instance, that will be made available to the commands via `this.context`.
  */
@@ -227,111 +332,6 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
       cli.register(commandClass);
 
     return cli;
-  }
-
-  static async runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>): Promise<void>;
-  static async runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<void>;
-
-  static async runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>): Promise<void>;
-  static async runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<void>;
-
-  static async runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<void>;
-  static async runExit<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<void>;
-
-  static async runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<void>;
-  static async runExit<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<void>;
-
-  static async runExit(...args: Array<any>) {
-    const {
-      resolvedOptions,
-      resolvedCommandClasses,
-      resolvedArgv,
-      resolvedContext,
-    } = Cli.resolveRunParameters(args);
-
-    const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
-    return cli.runExit(resolvedArgv, resolvedContext);
-  }
-
-  static async run<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>): Promise<number>;
-  static async run<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<number>;
-
-  static async run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>): Promise<number>;
-  static async run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, context: RunContext<Context>): Promise<number>;
-
-  static async run<Context extends BaseContext = BaseContext>(commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<number>;
-  static async run<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<number>;
-
-  static async run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommandNoContext<Context>, argv: Array<string>): Promise<number>;
-  static async run<Context extends BaseContext = BaseContext>(options: Partial<CliOptions>, commandClasses: RunCommand<Context>, argv: Array<string>, context: RunContext<Context>): Promise<number>;
-
-  static async run(...args: Array<any>) {
-    const {
-      resolvedOptions,
-      resolvedCommandClasses,
-      resolvedArgv,
-      resolvedContext,
-    } = Cli.resolveRunParameters(args);
-
-    const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
-    return cli.run(resolvedArgv, resolvedContext);
-  }
-
-  private static resolveRunParameters(args: Array<any>) {
-    let resolvedOptions: any;
-    let resolvedCommandClasses: any;
-    let resolvedArgv: any;
-    let resolvedContext: any;
-
-    switch (args.length) {
-      case 1: {
-        resolvedCommandClasses = args[0];
-      } break;
-
-      case 2: {
-        if (args[0] && (args[0].prototype instanceof Command) || Array.isArray(args[0])) {
-          resolvedCommandClasses = args[0];
-          if (Array.isArray(args[1])) {
-            resolvedArgv = args[1];
-          } else {
-            resolvedContext = args[1];
-          }
-        } else {
-          resolvedOptions = args[0];
-          resolvedCommandClasses = args[1];
-        }
-      } break;
-
-      case 3: {
-        if (Array.isArray(args[2])) {
-          resolvedOptions = args[0];
-          resolvedCommandClasses = args[1];
-          resolvedArgv = args[2];
-        } else if (args[1] && (args[1].prototype instanceof Command) || Array.isArray(args[1])) {
-          resolvedOptions = args[0];
-          resolvedCommandClasses = args[1];
-          resolvedContext = args[2];
-        } else {
-          resolvedCommandClasses = args[0];
-          resolvedArgv = args[1];
-          resolvedContext = args[2];
-        }
-      } break;
-
-      default: {
-        resolvedOptions = args[0];
-        resolvedCommandClasses = args[1];
-        resolvedArgv = args[2];
-        resolvedContext = args[3];
-      } break;
-    }
-
-    return {
-      resolvedOptions,
-      resolvedCommandClasses,
-      resolvedArgv,
-      resolvedContext,
-    };
   }
 
   constructor({binaryLabel, binaryName: binaryNameOpt = `...`, binaryVersion, enableCapture = false, enableColors}: Partial<CliOptions> = {}) {

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -6,6 +6,8 @@ export {CommandClass, Usage, Definition} from './Command';
 export {UsageError, ErrorMeta, ErrorWithMeta} from '../errors';
 export {formatMarkdownish, ColorFormat} from '../format';
 
+export {run, runExit} from './Cli';
+
 export * as Builtins from './builtins';
 export * as Option from './options';
 

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -122,47 +122,47 @@ class MyCommand extends Command {
   }
 }
 
-Cli.runExit(class FooCommand extends Command {
+runExit(class FooCommand extends Command {
   async execute() {}
 });
 
-Cli.runExit(class FooCommand extends Command {
-  async execute() {}
-}, {
-  stdin: process.stdin,
-});
-
-Cli.runExit({
-  binaryLabel: `Foo`,
-}, class FooCommand extends Command {
-  async execute() {}
-});
-
-Cli.runExit({
-  binaryLabel: `Foo`,
-}, class FooCommand extends Command {
+runExit(class FooCommand extends Command {
   async execute() {}
 }, {
   stdin: process.stdin,
 });
 
-Cli.runExit(class FooCommand extends Command {
+runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+});
+
+runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+}, {
+  stdin: process.stdin,
+});
+
+runExit(class FooCommand extends Command {
   async execute() {}
 }, []);
 
-Cli.runExit(class FooCommand extends Command {
+runExit(class FooCommand extends Command {
   async execute() {}
 }, [], {
   stdin: process.stdin,
 });
 
-Cli.runExit({
+runExit({
   binaryLabel: `Foo`,
 }, class FooCommand extends Command {
   async execute() {}
 }, []);
 
-Cli.runExit({
+runExit({
   binaryLabel: `Foo`,
 }, class FooCommand extends Command {
   async execute() {}

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as t            from 'typanion';
+import * as t                 from 'typanion';
 
-import {Command, Option} from '..';
+import {Cli, Command, Option} from '..';
 
 type AssertEqual<T, Expected> = [T, Expected] extends [Expected, T] ? true : false;
 
@@ -121,3 +121,51 @@ class MyCommand extends Command {
     assertEqual<Array<string>>()(this.proxy, true);
   }
 }
+
+Cli.runExit(class FooCommand extends Command {
+  async execute() {}
+});
+
+Cli.runExit(class FooCommand extends Command {
+  async execute() {}
+}, {
+  stdin: process.stdin,
+});
+
+Cli.runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+});
+
+Cli.runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+}, {
+  stdin: process.stdin,
+});
+
+Cli.runExit(class FooCommand extends Command {
+  async execute() {}
+}, []);
+
+Cli.runExit(class FooCommand extends Command {
+  async execute() {}
+}, [], {
+  stdin: process.stdin,
+});
+
+Cli.runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+}, []);
+
+Cli.runExit({
+  binaryLabel: `Foo`,
+}, class FooCommand extends Command {
+  async execute() {}
+}, [], {
+  stdin: process.stdin,
+});

--- a/tests/inference.ts
+++ b/tests/inference.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import * as t                 from 'typanion';
+import * as t            from 'typanion';
 
-import {Cli, Command, Option} from '..';
+import {runExit}         from '../sources/advanced/Cli';
+import {Command, Option} from '..';
 
 type AssertEqual<T, Expected> = [T, Expected] extends [Expected, T] ? true : false;
 

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -5,6 +5,15 @@ title: Cli
 
 The `Cli` class is the main way you'll interact with your cli.
 
+## `Cli.runExit` / `Cli.run`
+
+```ts
+Cli.run(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
+Cli.runExit(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
+```
+
+Those static method abstracts all the functions below under simple helpers that decrease the amount of boilerplate needed to boot your CLI.
+
 ## `new Cli`
 
 ```ts

--- a/website/docs/api/cli.md
+++ b/website/docs/api/cli.md
@@ -3,17 +3,6 @@ id: cli
 title: Cli
 ---
 
-The `Cli` class is the main way you'll interact with your cli.
-
-## `Cli.runExit` / `Cli.run`
-
-```ts
-Cli.run(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
-Cli.runExit(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
-```
-
-Those static method abstracts all the functions below under simple helpers that decrease the amount of boilerplate needed to boot your CLI.
-
 ## `new Cli`
 
 ```ts

--- a/website/docs/api/helpers.md
+++ b/website/docs/api/helpers.md
@@ -1,0 +1,17 @@
+---
+id: helpers
+title: Helpers
+---
+
+## `runExit` / `run`
+
+```ts
+run(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
+runExit(opts?: {...}, commands: Command | Command[], argv?: string[], context?: Context)
+```
+
+Those functions abstracts the `Cli` class behind simple helpers, decreasing the amount of boilerplate you need to write when building small CLIs.
+
+All parameters except the commands (and the [context](/docs/contexts), if you specify custom keys) are optional and will default to sensible values from the current environment.
+
+Calling `run` will return a promise with the exit code that you'll need to handle yourself, whereas `runExit` will set the process exit code itself.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -35,7 +35,7 @@ Note that `execute` is using `this.context.stdout.write` rather than `console.lo
 
 ## Execute your CLI
 
-Now that your command is ready, all you have to do is setup the CLI engine that will "serve" this command. To do that, instantiate a new CLI, register your command into it, then apply it on the process arguments:
+Now that your command is ready, all you have to do is setup the CLI engine that will "serve" this command. To do that, you can instantiate a new CLI, register your command into it, then apply it on the process arguments:
 
 ```ts
 import {Cli} from 'clipanion';
@@ -52,4 +52,17 @@ const cli = new Cli({
 
 cli.register(HelloCommand);
 cli.runExit(args);
+```
+
+Or you can use the `Cli.runExit` helper which abstracts all that for you:
+
+```ts
+import {Cli} from 'clipanion';
+
+import {HelloCommand} from './HelloCommand';
+
+Cli.runExit({
+    binaryLabel: `My Application`,
+    binaryVersion: `1.0.0`,
+}, HelloCommand);
 ```


### PR DESCRIPTION
Clipanion is currently a little annoying to use with single-command scripts because of its boilerplate. The new `runExit` API lets you write small CLIs even more easily:

```ts
import {Command, runExit} from 'clipanion';

runExit(class extends Command {
  async execute() {
    // ...
  }
});
```
