### PR TITLE
Adds .env option to Option.String

### DIFF
--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -5,12 +5,14 @@ import {NoLimits}                                                               
 import {applyValidator, CommandOptionReturn, GeneralOptionFlags, makeCommandOption, rerouteArguments, WithArity} from "./utils";
 
 export type StringOptionNoBoolean<T, Arity extends number = 1> = GeneralOptionFlags & {
+  env?: string,
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean?: false,
   arity?: Arity,
 };
 
 export type StringOptionTolerateBoolean<T> = GeneralOptionFlags & {
+  env?: string,
   validator?: StrictValidator<unknown, T>,
   tolerateBoolean: boolean,
   arity?: 0,
@@ -52,9 +54,14 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
       });
     },
 
-    transformer(builder, key, state) {
+    transformer(builder, key, state, context) {
       let usedName;
       let currentValue = initialValue;
+
+      if (typeof opts.env !== `undefined` && context.env[opts.env]) {
+        usedName = opts.env;
+        currentValue = context.env[opts.env];
+      }
 
       for (const {name, value} of state.options) {
         if (!nameSet.has(name))

--- a/sources/advanced/options/utils.ts
+++ b/sources/advanced/options/utils.ts
@@ -35,7 +35,7 @@ export type WithArity<Type, Arity extends number> = Arity extends 0
 export type CommandOption<T> = {
   [isOptionSymbol]: true,
   definition: <Context extends BaseContext>(builder: CommandBuilder<CliContext<Context>>, key: string) => void,
-  transformer: <Context extends BaseContext>(builder: CommandBuilder<CliContext<Context>>, key: string, state: RunState) => T,
+  transformer: <Context extends BaseContext>(builder: CommandBuilder<CliContext<Context>>, key: string, state: RunState, context: Context) => T,
 };
 
 export type CommandOptionReturn<T> = T;

--- a/tests/advanced.test.ts
+++ b/tests/advanced.test.ts
@@ -428,6 +428,48 @@ describe(`Advanced`, () => {
     expect(cli.usage(CommandA)).to.equal(`\u001b[1m$ \u001b[22m... clean <workspaceNames> <workspaceNames> ...\n`);
   });
 
+  it(`supports populating strings with environment variables`, async () => {
+    class CommandA extends Command {
+      foo = Option.String(`--foo`, {env: `TEST_FOO`});
+
+      async execute() {
+        log(this, [`foo`]);
+      }
+    }
+
+    const cli = Cli.from([CommandA]);
+
+    expect(cli.process([], {env: {TEST_FOO: `bar`}})).to.contain({foo: `bar`});
+  });
+
+  it(`overrides defaults with environment variables`, async () => {
+    class CommandA extends Command {
+      foo = Option.String(`--foo`, `foo`, {env: `TEST_FOO`});
+
+      async execute() {
+        log(this, [`foo`]);
+      }
+    }
+
+    const cli = Cli.from([CommandA]);
+
+    expect(cli.process([], {env: {TEST_FOO: `bar`}})).to.contain({foo: `bar`});
+  });
+
+  it(`overrides environment variables with options`, async () => {
+    class CommandA extends Command {
+      foo = Option.String(`--foo`, {env: `TEST_FOO`});
+
+      async execute() {
+        log(this, [`foo`]);
+      }
+    }
+
+    const cli = Cli.from([CommandA]);
+
+    expect(cli.process([`--foo=qux`], {env: {TEST_FOO: `bar`}})).to.contain({foo: `qux`});
+  });
+
   it(`supports strings that act like booleans if not bound to a value`, async () => {
     class CommandA extends Command {
       enableDebugger = Option.String(`--break`, false, {tolerateBoolean: true});

--- a/website/docs/api/option.md
+++ b/website/docs/api/option.md
@@ -235,11 +235,14 @@ Option.String(optionNames: string, default?: string, opts?: {...})
 | --- | --- | --- |
 | `arity` | `number` | Number of arguments for the option |
 | `description` | `string`| Short description for the help message |
+| `env` | `string` | Name of an environment variable |
 | `hidden` | `boolean` | Hide the option from any usage list |
 | `tolerateBoolean` | `boolean` | Accept the option even if no argument is provided |
 | `required` | `boolean` | Whether at least a single occurrence of the option is required or not |
 
 Specifies that the command accepts an option that takes arguments (by default one, unless overriden via `arity`). If no default value is provided, the option will start as `undefined`.
+
+If `env` is set and the specified environment variable is non-empty, it'll override the default value if necessary. Note that explicit options still take precedence over env values.
 
 ```ts
 class TestCommand extends Command {

--- a/website/docs/contexts.md
+++ b/website/docs/contexts.md
@@ -7,9 +7,11 @@ In Clipanion commands have what we call a *context*. Under this fancy word is si
 
 ```ts
 interface BaseContext {
+    env: Record<string, string | undefined>;
     stdin: Readable;
     stdout: Writable;
     stderr: Writable;
+    colorDepth: number;
 }
 ```
 


### PR DESCRIPTION
I'm writing GitHub Actions powered by Clipanion, and some values (in particular `GITHUB_TOKEN`) are meant to be obtained from the environment. At the same time, it'd be beneficial to validate/coerce them like regular options and to allow options to override them. To this end, I added `env` into the context (which will be useful for [griselbrand](https://github.com/arcanis/griselbrand)) and added an option to inject environment variables after default values, but before options.