### PR TITLE
Implements array validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "website"
   ],
   "dependencies": {
-    "typanion": "^3.3.1"
+    "typanion": "^3.8.0"
   },
   "peerDependencies": {
     "typanion": "*"

--- a/sources/advanced/options/utils.ts
+++ b/sources/advanced/options/utils.ts
@@ -24,13 +24,16 @@ export type Tuple<Type, Arity extends number> = Arity extends Arity
     : TupleOf<Type, Arity, []>
   : never;
 
-export type WithArity<Type, Arity extends number> = Arity extends 0
-  ? boolean
-  : Arity extends 1
-    ? Type
-    : number extends Arity
-      ? boolean | Type | Tuple<Type, Arity>
-      : Tuple<Type, Arity>;
+export type WithArity<Type extends {length?: number}, Arity extends number> =
+  number extends Type['length']
+    ? Arity extends 0
+      ? boolean
+      : Arity extends 1
+        ? Type
+        : number extends Arity
+          ? boolean | Type | Tuple<Type, Arity>
+          : Tuple<Type, Arity>
+    : Type;
 
 export type CommandOption<T> = {
   [isOptionSymbol]: true,
@@ -58,18 +61,25 @@ export function rerouteArguments<A, B>(a: A | B | undefined, b: B): [Exclude<A, 
   }
 }
 
-export function cleanValidationError(message: string, lowerCase: boolean = false) {
-  let cleaned = message.replace(/^\.: /, ``);
+export function cleanValidationError(message: string, {mergeName = false}: {mergeName?: boolean} = {}) {
+  const match = message.match(/^([^:]+): (.*)$/m);
+  if (!match)
+    return `validation failed`;
 
-  if (lowerCase)
-    cleaned = cleaned[0].toLowerCase() + cleaned.slice(1);
+  let [, path, line] = match;
+  if (mergeName)
+    line = line[0].toLowerCase() + line.slice(1);
 
-  return cleaned;
+  line = path !== `.` || !mergeName
+    ? `${path.replace(/^\.(\[|$)/, `$1`)}: ${line}`
+    : `: ${line}`;
+
+  return line;
 }
 
 export function formatError(message: string, errors: Array<string>) {
   if (errors.length === 1) {
-    return new UsageError(`${message}: ${cleanValidationError(errors[0], true)}`);
+    return new UsageError(`${message}${cleanValidationError(errors[0], {mergeName: true})}`);
   } else {
     return new UsageError(`${message}:\n${errors.map(error => `\n- ${cleanValidationError(error)}`).join(``)}`);
   }

--- a/tests/specs/inference.ts
+++ b/tests/specs/inference.ts
@@ -70,6 +70,8 @@ class MyCommand extends Command {
   arrayWithArity3AndRequired = Option.Array(`--foo`, {arity: 3, required: true});
   // @ts-expect-error: Overload prevents this
   arrayWithArity3AndRequiredAndDefault = Option.Array(`--foo`, [], {arity: 3, required: true});
+  arrayWithValidator = Option.Array(`--foo`, {validator: t.isArray(t.isNumber())});
+  arrayWithTupleValidator = Option.Array(`--foo`, {arity: 2, validator: t.isArray(t.isTuple([t.isNumber(), t.isBoolean()]))});
 
   rest = Option.Rest();
   proxy = Option.Proxy();
@@ -117,6 +119,8 @@ class MyCommand extends Command {
     assertEqual<Array<[string, string, string]> | undefined>()(this.arrayWithArity3, true);
     assertEqual<Array<[string, string, string]>>()(this.arrayWithArity3AndDefault, true);
     assertEqual<Array<[string, string, string]>>()(this.arrayWithArity3AndRequired, true);
+    assertEqual<Array<number> | undefined>()(this.arrayWithValidator, true);
+    assertEqual<Array<[number, boolean]> | undefined>()(this.arrayWithTupleValidator, true);
 
     assertEqual<Array<string>>()(this.rest, true);
     assertEqual<Array<string>>()(this.proxy, true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,7 +1051,7 @@ __metadata:
     rollup-plugin-multi-input: ^1.3.1
     ts-node: ^8.10.2
     tslib: ^2.0.0
-    typanion: ^3.3.1
+    typanion: ^3.8.0
     typescript: ^4.1.2
   peerDependencies:
     typanion: "*"
@@ -3894,10 +3894,10 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"typanion@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "typanion@npm:3.3.1"
-  checksum: 212d2beb5502028f7879c90508cd7695d83a32b95d9323870d2a2c8b21f68e4cdf2bafbfdd6a2c8f3a37329355e3d5ec6e99c97eecd422adcd8e07011ee7668b
+"typanion@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "typanion@npm:3.8.0"
+  checksum: ea3f97072c72efd4f1ac2c8996dad61e2a0810e6e2835f72b1e076e3f4c796666dc5f60af88329f3892173419a114b5d58a7369c16fdc46d76e3d9a55e8c486d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `validator` option wasn't supported for `Option.Array`. This diff fixes that.