### PR TITLE
fix --help not working if required fields present

### DIFF
--- a/sources/core.ts
+++ b/sources/core.ts
@@ -874,6 +874,7 @@ export class CommandBuilder<Context> {
       if (this.arity.leading.length > 0 || !this.arity.proxy) {
         const helpNode = injectNode(machine, makeNode());
         registerDynamic(machine, lastPathNode, `isHelp`, helpNode, [`useHelp`, this.cliIndex]);
+        registerDynamic(machine, helpNode, `always`, helpNode, `pushExtra`);
         registerStatic(machine, helpNode, END_OF_INPUT, NODE_SUCCESS, [`setSelectedIndex`, HELP_COMMAND_INDEX]);
 
         this.registerOptions(machine, lastPathNode);

--- a/tests/specs/advanced.test.ts
+++ b/tests/specs/advanced.test.ts
@@ -56,6 +56,7 @@ describe(`Advanced`, () => {
           static paths = [[`foo`]];
 
           foo = Option.Boolean(`--foo`);
+          bar = Option.Boolean(`--bar`, {required: true});
           async execute() {log(this);}
         }
 

--- a/tests/specs/advanced.test.ts
+++ b/tests/specs/advanced.test.ts
@@ -56,7 +56,6 @@ describe(`Advanced`, () => {
           static paths = [[`foo`]];
 
           foo = Option.Boolean(`--foo`);
-          bar = Option.Boolean(`--bar`, {required: true});
           async execute() {log(this);}
         }
 
@@ -64,6 +63,7 @@ describe(`Advanced`, () => {
 
         expect(await runCli(cli, [`foo`, `-h`])).to.equal(cli.usage(CommandA));
         expect(await runCli(cli, [`foo`, `--help`])).to.equal(cli.usage(CommandA));
+        expect(await runCli(cli, [`foo`, `--help`, `--foo`])).to.equal(cli.usage(CommandA));
       });
 
       it(`should display the command usage if there's a single one and it's the default`, async () => {
@@ -1058,6 +1058,55 @@ describe(`Advanced`, () => {
     expect(await runCli(cli, [`--foo`])).to.equal(`Running FooCommand\n`);
     await expect(runCli(cli, [`--bar`])).to.be.rejectedWith(`Command not found; did you mean:`);
     expect(await runCli(cli, [`--foo`, `--bar`])).to.equal(`Running FooBarCommand\n`);
+  });
+
+  it(`should support --help even for commands with required options`, async () => {
+    const cli = new Cli();
+    cli.register(Builtins.HelpCommand);
+
+    class CommandA extends Command {
+      static paths = [[`foo`]];
+
+      foo = Option.Boolean(`--foo`);
+      bar = Option.Boolean(`--bar`, {required: true});
+      async execute() {log(this);}
+    }
+
+    cli.register(CommandA);
+
+    expect(await runCli(cli, [`foo`, `--help`])).to.equal(cli.usage(CommandA));
+  });
+
+  it(`should support --help even when used before other arguments`, async () => {
+    const cli = new Cli();
+    cli.register(Builtins.HelpCommand);
+
+    class CommandA extends Command {
+      static paths = [[`foo`]];
+
+      foo = Option.Boolean(`--foo`);
+      async execute() {log(this);}
+    }
+
+    cli.register(CommandA);
+
+    expect(await runCli(cli, [`foo`, `--help`, `--foo`])).to.equal(cli.usage(CommandA));
+  });
+
+  it(`should support --help even when used before required options`, async () => {
+    const cli = new Cli();
+    cli.register(Builtins.HelpCommand);
+
+    class CommandA extends Command {
+      static paths = [[`foo`]];
+
+      foo = Option.Boolean(`--foo`, {required: true});
+      async execute() {log(this);}
+    }
+
+    cli.register(CommandA);
+
+    expect(await runCli(cli, [`foo`, `--help`, `--foo`])).to.equal(cli.usage(CommandA));
   });
 
   it(`should show the reason if the single branch errors`, async () => {


### PR DESCRIPTION
### Summary
`--help` not working if an option is `required: true`.

fixes #101 

### Changes

- `selectBestState` that runs the required field checks skips it if it's the help command
- Display the `--help` even if `--help --foo` has other options following

### Further thoughts

I think Unix commands usually display the help by default when you input an unknown option. That seems like a good practice to adopt