### PR TITLE
Fix "TypeError: tty__default.default.WriteStream.prototype is not an Object"

### DIFF
--- a/sources/platform/node.ts
+++ b/sources/platform/node.ts
@@ -1,10 +1,10 @@
 import {AsyncLocalStorage} from 'async_hooks';
-import tty                 from 'tty';
+import * as tty            from 'tty';
 
 import {BaseContext}       from '../advanced/Cli';
 
 export function getDefaultColorDepth() {
-  if (tty && `getColorDepth` in tty.WriteStream.prototype)
+  if (typeof tty?.WriteStream?.prototype?.getColorDepth === `function`)
     return tty.WriteStream.prototype.getColorDepth();
 
   if (process.env.FORCE_COLOR === `0`)


### PR DESCRIPTION
The rollup-compiled .js version of the distributable `lib/platform/node.js` tries to access the `default` property of the `default` export from the `'tty'` package. Somehow this works in `node` (probably because node circularly re-wraps `default` export), but fails in `bun`, which is more strict.
The code generated by Rollup is clearly invalid (offending part `tty__default['default']`). 

This PR fixes the problem by correcting the `tty` import, and changing the check for `getColorDepth` function to be a little more permissive (WriteStream is not fully implemented in bun yet).

Original error:

```
 7 | function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 8 | 
 9 | var tty__default = /*#__PURE__*/_interopDefaultLegacy(tty);
10 | 
11 | function getDefaultColorDepth() {
12 |     if (tty__default['default'] && `getColorDepth` in tty__default['default'].WriteStream.prototype)
                                       ^
TypeError: tty__default.default.WriteStream.prototype is not an Object. (evaluating '"getColorDepth" in tty__default.default.WriteStream.prototype')
      at getDefaultColorDepth (/node_modules/clipanion/lib/platform/node.js:12:35)
      at /node_modules/clipanion/lib/advanced/Cli.js:454:16
      at globalThis (/node_modules/clipanion/lib/advanced/Cli.js:462:18)
```

Offending code:

<img width="987" alt="Screenshot 2023-08-14 at 22 56 10" src="https://github.com/arcanis/clipanion/assets/563469/4e381b9a-abd2-4128-83b9-431f6d602096">

