### PR TITLE
Adds support for lazy commands

### DIFF
--- a/demos/yarn/DemoCommand.ts
+++ b/demos/yarn/DemoCommand.ts
@@ -1,0 +1,7 @@
+import {Command} from "../../sources/advanced";
+
+export class DemoCommand extends Command {
+  async execute() {
+    console.log(`Executing`, this.path);
+  }
+}

--- a/demos/yarn/cli.ts
+++ b/demos/yarn/cli.ts
@@ -1,0 +1,12 @@
+import {Cli, runExit} from "../../sources/advanced";
+
+const commands = Cli.lazyFileSystem({
+  cwd: `${__dirname}/commands`,
+  pattern: `{}.ts`,
+});
+
+runExit({
+  binaryLabel: `Fake Yarn`,
+  binaryName: `fake-yarn`,
+  binaryVersion: `0.0.0`,
+}, commands);

--- a/demos/yarn/commands/add.ts
+++ b/demos/yarn/commands/add.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../DemoCommand";
+
+export class AddCommand extends DemoCommand {
+  static paths = [[`add`]];
+}

--- a/demos/yarn/commands/config.ts
+++ b/demos/yarn/commands/config.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../DemoCommand";
+
+export class ConfigCommand extends DemoCommand {
+  static paths = [[`config`]];
+}

--- a/demos/yarn/commands/config/get.ts
+++ b/demos/yarn/commands/config/get.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../DemoCommand";
+
+export class ConfigGetCommand extends DemoCommand {
+  static paths = [[`config`, `get`]];
+}

--- a/demos/yarn/commands/config/set.ts
+++ b/demos/yarn/commands/config/set.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../DemoCommand";
+
+export class ConfigSetCommand extends DemoCommand {
+  static paths = [[`config`, `set`]];
+}

--- a/demos/yarn/commands/install.ts
+++ b/demos/yarn/commands/install.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../DemoCommand";
+
+export class InstallCommand extends DemoCommand {
+  static paths = [[`install`]];
+}

--- a/demos/yarn/commands/remove.ts
+++ b/demos/yarn/commands/remove.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../DemoCommand";
+
+export class RemoveCommand extends DemoCommand {
+  static paths = [[`remove`]];
+}

--- a/demos/yarn/commands/run.ts
+++ b/demos/yarn/commands/run.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../DemoCommand";
+
+export class RunCommand extends DemoCommand {
+  static paths = [[`run`]];
+}

--- a/demos/yarn/commands/set/version.ts
+++ b/demos/yarn/commands/set/version.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../DemoCommand";
+
+export class SetVersionCommand extends DemoCommand {
+  static paths = [[`set`, `version`]];
+}

--- a/demos/yarn/commands/set/version/from/sources.ts
+++ b/demos/yarn/commands/set/version/from/sources.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../../../DemoCommand";
+
+export class SetVersionFromSourcesCommand extends DemoCommand {
+  static paths = [[`set`, `version`, `from`, `sources`]];
+}

--- a/demos/yarn/commands/workspaces/focus.ts
+++ b/demos/yarn/commands/workspaces/focus.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../DemoCommand";
+
+export class WorkspacesFocusCommand extends DemoCommand {
+  static paths = [[`workspaces`, `focus`]];
+}

--- a/demos/yarn/commands/workspaces/foreach.ts
+++ b/demos/yarn/commands/workspaces/foreach.ts
@@ -1,0 +1,5 @@
+import {DemoCommand} from "../../DemoCommand";
+
+export class WorkspaceForeachCommand extends DemoCommand {
+  static paths = [[`workspaces`, `foreach`]];
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "postpack": "rm -rf lib",
     "lint": "eslint --max-warnings 0 .",
     "test": "jest",
+    "demo-yarn": "node --require ts-node/register demos/yarn/cli.ts",
     "demo": "node --require ts-node/register demos/advanced.ts"
   },
   "publishConfig": {

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -4,6 +4,7 @@ import {HELP_COMMAND_INDEX}                                     from '../constan
 import {CliBuilder, CommandBuilder}                             from '../core';
 import {ErrorMeta}                                              from '../errors';
 import {formatMarkdownish, ColorFormat, richFormat, textFormat} from '../format';
+import {LazyTree, lazyTree}                                     from '../lazy';
 import * as platform                                            from '../platform';
 
 import {CommandClass, Command, Definition}                      from './Command';
@@ -75,11 +76,13 @@ export type RunContext<Context extends BaseContext = BaseContext> =
   & UserContext<Context>;
 
 export type RunCommand<Context extends BaseContext = BaseContext> =
+  | ((args: Array<string>) => RunCommand<Context>)
+  | Promise<CommandClass<Context> | Array<CommandClass<Context>>>
   | Array<CommandClass<Context>>
   | CommandClass<Context>;
 
 export type RunCommandNoContext<Context extends BaseContext = BaseContext> =
-  UserContextKeys<Context> extends never
+  [UserContextKeys<Context>] extends [never]
     ? RunCommand<Context>
     : never;
 
@@ -229,9 +232,10 @@ export async function runExit(...args: Array<any>) {
     resolvedCommandClasses,
     resolvedArgv,
     resolvedContext,
-  } = resolveRunParameters(args);
+  } = await resolveRunParameters(args);
 
   const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
+
   return cli.runExit(resolvedArgv, resolvedContext);
 }
 
@@ -262,13 +266,13 @@ export async function run(...args: Array<any>) {
     resolvedCommandClasses,
     resolvedArgv,
     resolvedContext,
-  } = resolveRunParameters(args);
+  } = await resolveRunParameters(args);
 
   const cli = Cli.from(resolvedCommandClasses, resolvedOptions);
   return cli.run(resolvedArgv, resolvedContext);
 }
 
-function resolveRunParameters(args: Array<any>) {
+async function resolveRunParameters(args: Array<any>) {
   let resolvedOptions: any;
   let resolvedCommandClasses: any;
   let resolvedArgv: any;
@@ -277,13 +281,16 @@ function resolveRunParameters(args: Array<any>) {
   if (typeof process !== `undefined` && typeof process.argv !== `undefined`)
     resolvedArgv = process.argv.slice(2);
 
+  const isCommandArg = (arg: any) =>
+    arg && (Command.isCommandClass(arg) || Array.isArray(arg) || typeof arg === `function` || `then` in arg);
+
   switch (args.length) {
     case 1: {
       resolvedCommandClasses = args[0];
     } break;
 
     case 2: {
-      if (args[0] && (args[0].prototype instanceof Command) || Array.isArray(args[0])) {
+      if (isCommandArg(args[0])) {
         resolvedCommandClasses = args[0];
         if (Array.isArray(args[1])) {
           resolvedArgv = args[1];
@@ -301,7 +308,7 @@ function resolveRunParameters(args: Array<any>) {
         resolvedOptions = args[0];
         resolvedCommandClasses = args[1];
         resolvedArgv = args[2];
-      } else if (args[0] && (args[0].prototype instanceof Command) || Array.isArray(args[0])) {
+      } else if (isCommandArg(args[0])) {
         resolvedCommandClasses = args[0];
         resolvedArgv = args[1];
         resolvedContext = args[2];
@@ -322,6 +329,11 @@ function resolveRunParameters(args: Array<any>) {
 
   if (typeof resolvedArgv === `undefined`)
     throw new Error(`The argv parameter must be provided when running Clipanion outside of a Node context`);
+
+  if (typeof resolvedCommandClasses === `function`)
+    resolvedCommandClasses = resolvedCommandClasses(resolvedArgv);
+
+  resolvedCommandClasses = await resolvedCommandClasses;
 
   return {
     resolvedOptions,
@@ -369,7 +381,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
    * @param commandClasses The Commands to register
    * @returns The created `Cli` instance
    */
-  static from<Context extends BaseContext = BaseContext>(commandClasses: RunCommand<Context>, options: Partial<CliOptions> = {}) {
+  static from<Context extends BaseContext = BaseContext>(commandClasses: Exclude<RunCommand<Context>, Promise<any> | Function>, options: Partial<CliOptions> = {}) {
     const cli = new Cli<Context>(options);
 
     const resolvedCommandClasses = Array.isArray(commandClasses)
@@ -380,6 +392,59 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
       cli.register(commandClass);
 
     return cli;
+  }
+
+  /**
+   * Return a function that can lazily load commands from the filesystem.
+   *
+   * This function is intended to be used conjointly with `runExit`, to avoid
+   * loading ALL the commands from an application when you only need one.
+   *
+   * For this function to work, it's assumed that the provided directory
+   * structure has a 1:1 mapping to the command paths. For instance, if you
+   * have a command whose path is `foo bar`, it should be located at
+   * `<cwd>/foo/bar.ts`.
+   *
+   * Since `lazyFileSystem` relies on the filesystem, it won't work in runtimes
+   * that don't implement the Node.js `fs` module, or where the filesystem 1:1
+   * mapping doesn't apply (for example if you bundle your CLI). In those cases,
+   * you should use `lazyTree` instead.
+   *
+   * @param cwd The directory from which the commands will be loaded
+   * @returns A function that will load the commands when called
+   */
+  static lazyFileSystem<Context extends BaseContext = BaseContext>(opts: {cwd: string, pattern: string}) {
+    return async (args: Array<string>) => {
+      const commands = await platform.lazyFileSystem(args, opts);
+
+      return commands.flatMap((val: unknown): Array<CommandClass<Context>> => {
+        if (Command.isCommandClass<Context>(val))
+          return [val];
+
+        if (typeof val === `object` && val !== null)
+          return Object.values(val).filter((val: unknown) => Command.isCommandClass(val));
+
+        return [];
+      });
+    };
+  }
+
+  /**
+   * Return a function that can lazily load commands from the provided tree.
+   *
+   * This function is intended to be used conjointly with `runExit`, to avoid
+   * loading ALL the commands from an application when you only need one.
+   *
+   * Unlike `lazyFileSystem`, this function doesn't rely on the filesystem and
+   * can be used in any runtime. It's also suitable for CLI distributed bundled.
+   *
+   * @param tree The tree from which the commands will be loaded
+   * @returns A function that will load the commands when called
+   */
+  static lazyTree<Context extends BaseContext = BaseContext>(tree: LazyTree<CommandClass<Context>>) {
+    return async (args: Array<string>) => {
+      return lazyTree(args, tree);
+    };
   }
 
   constructor({binaryLabel, binaryName: binaryNameOpt = `...`, binaryVersion, enableCapture = false, enableColors}: Partial<CliOptions> = {}) {
@@ -448,8 +513,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
         command.tokens = state.tokens;
 
         return command;
-      } break;
-
+      }
       default: {
         const {commandClass} = contexts[state.selectedIndex!];
 
@@ -471,8 +535,7 @@ export class Cli<Context extends BaseContext = BaseContext> implements Omit<Mini
           error[errorCommandSymbol] = command;
           throw error;
         }
-      } break;
-    }
+      }    }
   }
 
   async run(input: Command<Context> | Array<string>, context: VoidIfEmpty<Omit<Context, keyof BaseContext>>): Promise<number>;

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -330,7 +330,7 @@ async function resolveRunParameters(args: Array<any>) {
   if (typeof resolvedArgv === `undefined`)
     throw new Error(`The argv parameter must be provided when running Clipanion outside of a Node context`);
 
-  if (typeof resolvedCommandClasses === `function`)
+  if (typeof resolvedCommandClasses === `function` && !Command.isCommandClass(resolvedCommandClasses))
     resolvedCommandClasses = resolvedCommandClasses(resolvedArgv);
 
   resolvedCommandClasses = await resolvedCommandClasses;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -84,6 +84,13 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
   declare [`constructor`]: CommandClass<Context>;
 
   /**
+   * Return true if the given parameter is a command class.
+   */
+  static isCommandClass<Context extends BaseContext = BaseContext>(value: unknown): value is CommandClass<Context> {
+    return typeof value === `function` && typeof value.prototype === `object` && value.prototype instanceof Command;
+  }
+
+  /**
    * @deprecated Do not use this; prefer the static `paths` property instead.
    */
   paths?: undefined;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -91,6 +91,19 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
   }
 
   /**
+   * Return all exported command definitions from a module exports object.
+   */
+  static extractFromModuleExports<Context extends BaseContext>(exports: any): Array<CommandClass<Context>> {
+    if (Command.isCommandClass<Context>(exports))
+      return [exports];
+
+    if (typeof exports === `object` && exports !== null)
+      return Object.values(exports).filter((val: unknown): val is CommandClass<Context> => Command.isCommandClass(exports));
+
+    return [];
+  }
+
+  /**
    * @deprecated Do not use this; prefer the static `paths` property instead.
    */
   paths?: undefined;

--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -98,7 +98,7 @@ export abstract class Command<Context extends BaseContext = BaseContext> {
       return [exports];
 
     if (typeof exports === `object` && exports !== null)
-      return Object.values(exports).filter((val: unknown): val is CommandClass<Context> => Command.isCommandClass(exports));
+      return Object.values(exports).filter((exportedValue: unknown): exportedValue is CommandClass<Context> => Command.isCommandClass(exportedValue));
 
     return [];
   }

--- a/sources/advanced/index.ts
+++ b/sources/advanced/index.ts
@@ -6,6 +6,7 @@ export {CommandClass, Usage, Definition} from './Command';
 export {Token} from '../core';
 export {UsageError, ErrorMeta, ErrorWithMeta} from '../errors';
 export {formatMarkdownish, ColorFormat} from '../format';
+export {LazyTree} from '../lazy';
 
 export {run, runExit} from './Cli';
 

--- a/sources/lazy.ts
+++ b/sources/lazy.ts
@@ -1,0 +1,68 @@
+function findIndexOrLength<T>(array: Array<T>, predicate: (value: T) => boolean) {
+  const index = array.findIndex(predicate);
+  return index !== -1 ? index : array.length;
+}
+
+export type LazyFactory<TContext, TRet> = (
+  segment: string,
+  ctx: TContext | undefined,
+) => Promise<{
+  context: TContext | null;
+  node: TRet | null;
+} | null>;
+
+export async function lazyFactory<TContext, TRet>(args: Array<string>, factory: LazyFactory<TContext, TRet>) {
+  const production: Array<TRet> = [];
+  const firstOptionIndex = findIndexOrLength(args, arg => arg[0] === `-`);
+
+  function loadBranch(argIndex: number, context?: TContext) {
+    if (argIndex >= firstOptionIndex) {
+      return Promise.all([loadBranchImpl(argIndex, context), loadBranchImpl(argIndex + 1, context)]);
+    } else {
+      return loadBranchImpl(argIndex, context);
+    }
+  }
+
+  async function loadBranchImpl(argIndex: number, context?: TContext) {
+    if (argIndex >= args.length)
+      return;
+
+    const res = await factory(args[argIndex], context);
+
+    if (res === null)
+      return;
+
+    if (res.node !== null)
+      production.push(res.node);
+
+    if (res.context !== null) {
+      await loadBranch(argIndex + 1, res.context);
+    }
+  }
+
+  await loadBranch(0);
+
+  return production.flat();
+}
+
+export type LazyTree<T> = {
+  [key: string]:
+  | (() => Promise<T>)
+  | LazyTree<T>
+};
+
+export async function lazyTree<T>(args: Array<string>, tree: LazyTree<T>) {
+  return lazyFactory(args, async (segment, ctx: LazyTree<T> = tree) => {
+    if (!Object.prototype.hasOwnProperty.call(ctx, segment))
+      return null;
+
+    const val = ctx[segment];
+    if (typeof val === `function`)
+      return {context: null, node: await val()};
+
+    if (typeof val.default === `function`)
+      return {context: val, node: await val.default()};
+
+    return {context: val, node: null};
+  });
+}

--- a/sources/platform/browser.ts
+++ b/sources/platform/browser.ts
@@ -5,3 +5,7 @@ export function getDefaultColorDepth() {
 export function getCaptureActivator() {
   throw new Error(`The enableCapture option cannot be used from within a browser environment`);
 }
+
+export function lazyFilesystem() {
+  throw new Error(`The lazyFileSystem feature cannot be used from within a browser environment`);
+}

--- a/sources/platform/browser.ts
+++ b/sources/platform/browser.ts
@@ -6,6 +6,6 @@ export function getCaptureActivator() {
   throw new Error(`The enableCapture option cannot be used from within a browser environment`);
 }
 
-export function lazyFilesystem() {
+export function lazyFileSystem() {
   throw new Error(`The lazyFileSystem feature cannot be used from within a browser environment`);
 }

--- a/tests/specs/bundling.test.ts
+++ b/tests/specs/bundling.test.ts
@@ -78,11 +78,11 @@ describe(`Browser support`, () => {
         onwarn: warning => warnings.push(warning),
       });
 
-      expect(warnings).toHaveLength(1);
-      expect(warnings).toMatchObject([{
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings).toEqual(expect.arrayContaining([expect.objectContaining({
         code: `UNRESOLVED_IMPORT`,
         source: `tty`,
-      }]);
+      })]));
     });
   }, 20000);
 });

--- a/tests/specs/lazy.test.ts
+++ b/tests/specs/lazy.test.ts
@@ -1,0 +1,74 @@
+import {lazyTree} from "../../sources/lazy";
+
+describe(`Lazy commands`, () => {
+  it(`should lazy-load commands based on the arguments`, async () => {
+    const commands = await lazyTree([`foo`], {
+      foo: async () => 1,
+    });
+
+    expect(commands).toEqual([
+      1,
+    ]);
+  });
+
+  it(`should keep looking for sub-command even after matching a first command`, async () => {
+    const commands = await lazyTree([`foo`, `bar`], {
+      foo: {
+        default: async () => 1,
+        bar: async () => 2,
+      },
+    });
+
+    expect(commands).toEqual([
+      1,
+      2,
+    ]);
+  });
+
+  it(`shouldn't look for sibling commands that can't match the provided arguments`, async () => {
+    const commands = await lazyTree([`foo`], {
+      foo: async () => 1,
+      bar: async () => 2,
+    });
+
+    expect(commands).toEqual([
+      1,
+    ]);
+  });
+
+  it(`shouldn't look for nested commands that can't match the provided arguments`, async () => {
+    const commands = await lazyTree([`foo`], {
+      foo: {
+        default: async () => 1,
+        bar: async () => 2,
+      },
+    });
+
+    expect(commands).toEqual([
+      1,
+    ]);
+  });
+
+  it(`should consider that options may be part of the path`, async () => {
+    const commands = await lazyTree([`--hello`], {
+      [`--hello`]: async () => 1,
+    });
+
+    expect(commands).toEqual([
+      1,
+    ]);
+  });
+
+  it(`should consider that options may have an arbitrary arity`, async () => {
+    const commands = await lazyTree([`--foo`, `hello`], {
+      [`--foo`]: async () => 1,
+      [`hello`] : async () => 2,
+      [`world`] : async () => 3,
+    });
+
+    expect(commands).toEqual([
+      1,
+      2,
+    ]);
+  });
+});

--- a/tests/specs/lazy.test.ts
+++ b/tests/specs/lazy.test.ts
@@ -4,7 +4,9 @@ describe(`Lazy commands`, () => {
   it(`should lazy-load commands based on the arguments`, async () => {
     const commands = await lazyTree([`foo`], {
       foo: {value: 1},
-    });
+    }, async val => [
+      val,
+    ]);
 
     expect(commands).toEqual([
       1,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "lib": [
       "DOM",
-      "ES2018"
+      "ES2019"
     ],
     "module": "commonjs",
     "noEmit": true,


### PR DESCRIPTION
This PR implements lazy commands, as described in #151.

Of note, I didn't go the road I initially described in https://github.com/arcanis/clipanion/issues/151#issuecomment-1750341951. I was worried the implementation would be very complicated and hard to follow / maintain, and perhaps would suffer in performances.

Instead, I opted to implement an helper that, given a argument list, can generate the set of commands that will be relevant. It means we essentially process the `argv` array twice, but since it's usually of small size, that shouldn't matter too much.

Two implementations are currently provided:

- `Cli.lazyTree` checks a recursive record to see whether subcommands exist that match the provided path.
- `Cli.lazyFileSystem` incrementally checks the filesystem to see if files matching the provided command paths exist.

> When writing large CLI application, we find ourselves in a pickle. Let's say we have commands similar to:
> 
> ```ts
> import something from './lib/something';
> import somethingElse from './lib/somethingElse';
> 
> export class MyCommand extends Command {
>   async execute() {
>     something();
>     somethingElse();
>   }
> }
> ```
> 
> The `something` and `somethingElse` functions aren't needed until `MyCommand` is executed, but since they are in a top-level import the generated code will still import them before even evaluating the command file. At the scale of a large application, those imports start to slow down the startup by a significant factor. We can mitigate it a little by doing something like this:
> 
> ```ts
> export class MyCommand extends Command {
>   async execute() {
>     const [{default: something}, {default: somethingElse}] = await Promise.all([
>       import('something'),
>       import('somethingElse'),
>     ]);
> 
>     something();
>     somethingElse();
>   }
> }
> ```
> 
> But that's really verbose, and that's not even what people doing things like this do (they instead just call `import` multiple times in a row, like top-level imports, except that it prevents the runtime from fetching / parsing the modules in parallel, making sync something that could be parallelized).
> 
> A second problem is that even if the imports are moved into `execute`, just running files has a cost. They need to be read, parsed, evaluated, and all that when they don't actually contribute to anything at all for the purpose of the command parsing. This problem is exacerbated when using transpilers, as the cost can easily reach hundreds of ms for larger CLIs.
> 
> The first point can be solved by the [Deferring Module Evaluation](https://github.com/tc39/proposal-defer-import-eval) proposal, but it's currently still at stage 2 (cc @nicolo-ribaudo in case you're interested by this thread / practical use case), and even with that we'd still have the problem of the files being executed at all (probably not as much a problem if you don't use a transpiler).
> 
> Ideally, I'd like to find a way to solve both points.

