### PR TITLE
fix: use the browser field in the root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jest": "^29.7.0",
     "lodash": "^4.17.21",
     "rollup": "^2.16.1",
-    "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-multi-input": "^1.3.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^8.10.2",
@@ -62,7 +61,12 @@
     "demo": "node --require ts-node/register demos/advanced.ts"
   },
   "publishConfig": {
-    "main": "lib/advanced/index"
+    "main": "lib/advanced/index",
+    "module": "lib/advanced/index.mjs",
+    "browser": {
+      "./lib/platform/node.js": "./lib/platform/browser.js",
+      "./lib/platform/node.mjs": "./lib/platform/browser.mjs"
+    }
   },
   "files": [
     "lib"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import ts         from '@rollup/plugin-typescript';
 import path       from 'path';
-import copy       from 'rollup-plugin-copy';
 import multiInput from 'rollup-plugin-multi-input';
 
 // Since we're using `multiInput`, the entries output path are already set.
@@ -26,7 +25,6 @@ export default {
   external: [
     `tty`,
     `typanion`,
-    `../platform`,
   ],
   plugins: [
     multiInput({
@@ -35,11 +33,6 @@ export default {
     ts({
       tsconfig: `tsconfig.dist.json`,
       include: `./sources/**/*`,
-    }),
-    copy({
-      targets: [
-        {src: `./sources/platform/package.json`, dest: `./lib/platform/`},
-      ],
     }),
   ],
 };

--- a/sources/advanced/Cli.ts
+++ b/sources/advanced/Cli.ts
@@ -4,7 +4,7 @@ import {HELP_COMMAND_INDEX}                                     from '../constan
 import {CliBuilder, CommandBuilder}                             from '../core';
 import {ErrorMeta}                                              from '../errors';
 import {formatMarkdownish, ColorFormat, richFormat, textFormat} from '../format';
-import * as platform                                            from '../platform';
+import * as platform                                            from '../platform/node';
 
 import {CommandClass, Command, Definition}                      from './Command';
 import {HelpCommand}                                            from './HelpCommand';

--- a/sources/platform/package.json
+++ b/sources/platform/package.json
@@ -1,4 +1,0 @@
-{
-    "main": "./node",
-    "browser": "./browser"
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,25 +1015,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/fs-extra@npm:^8.0.1":
-  version: 8.1.2
-  resolution: "@types/fs-extra@npm:8.1.2"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 837814d4c7d38f0546c106326e9ea92040456094b3b5fb62aa8f7802203147e1803a12a300a93dc627e83a2de46a6a9c53feb178f9894d6e35aa3a61caa0f013
-  languageName: node
-  linkType: hard
-
-"@types/glob@npm:^7.1.1":
-  version: 7.2.0
-  resolution: "@types/glob@npm:7.2.0"
-  dependencies:
-    "@types/minimatch": "npm:*"
-    "@types/node": "npm:*"
-  checksum: a8eb5d5cb5c48fc58c7ca3ff1e1ddf771ee07ca5043da6e4871e6757b4472e2e73b4cfef2644c38983174a4bc728c73f8da02845c28a1212f98cabd293ecae98
-  languageName: node
-  linkType: hard
-
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.9
   resolution: "@types/graceful-fs@npm:4.1.9"
@@ -1105,13 +1086,6 @@ __metadata:
   version: 4.14.179
   resolution: "@types/lodash@npm:4.14.179"
   checksum: 653e45c277e405577c1e4f5baeb0040589b805aa8dabea334c93e1ae44949f6071361754dbf933202de3fb73119f3ee12f317d0f0213168bb806d1ee7478b0ce
-  languageName: node
-  linkType: hard
-
-"@types/minimatch@npm:*":
-  version: 3.0.5
-  resolution: "@types/minimatch@npm:3.0.5"
-  checksum: a1a19ba342d6f39b569510f621ae4bbe972dc9378d15e9a5e47904c440ee60744f5b09225bc73be1c6490e3a9c938eee69eb53debf55ce1f15761201aa965f97
   languageName: node
   linkType: hard
 
@@ -2040,7 +2014,6 @@ __metadata:
     jest: "npm:^29.7.0"
     lodash: "npm:^4.17.21"
     rollup: "npm:^2.16.1"
-    rollup-plugin-copy: "npm:^3.4.0"
     rollup-plugin-multi-input: "npm:^1.3.1"
     ts-jest: "npm:^29.1.1"
     ts-node: "npm:^8.10.2"
@@ -2122,13 +2095,6 @@ __metadata:
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
-  languageName: node
-  linkType: hard
-
-"colorette@npm:^1.1.0":
-  version: 1.4.0
-  resolution: "colorette@npm:1.4.0"
-  checksum: 4955c8f7daafca8ae7081d672e4bd89d553bd5782b5846d5a7e05effe93c2f15f7e9c0cb46f341b59f579a39fcf436241ff79594899d75d5f3460c03d607fe9e
   languageName: node
   linkType: hard
 
@@ -2755,7 +2721,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.0.0, fast-glob@npm:^3.0.3":
+"fast-glob@npm:^3.0.0":
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
   dependencies:
@@ -2904,17 +2870,6 @@ __metadata:
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
   checksum: a0cde99085f0872f4d244e83e03a46aa387b74f5a5af750896c6b05e9077fac00e9932fdf5aef84f2f16634cd473c63037d7a512576da7d5c2b9163d1909f3a8
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "fs-extra@npm:8.1.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^4.0.0"
-    universalify: "npm:^0.1.0"
-  checksum: 259f7b814d9e50d686899550c4f9ded85c46c643f7fe19be69504888e007fcbc08f306fae8ec495b8b998635e997c9e3e175ff2eeed230524ef1c1684cc96423
   languageName: node
   linkType: hard
 
@@ -3127,22 +3082,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:10.0.1":
-  version: 10.0.1
-  resolution: "globby@npm:10.0.1"
-  dependencies:
-    "@types/glob": "npm:^7.1.1"
-    array-union: "npm:^2.1.0"
-    dir-glob: "npm:^3.0.1"
-    fast-glob: "npm:^3.0.3"
-    glob: "npm:^7.1.3"
-    ignore: "npm:^5.1.1"
-    merge2: "npm:^1.2.3"
-    slash: "npm:^3.0.0"
-  checksum: 048f8e19a5ff1b3d565372e66ac22050fcc9225ccf931ce7b0971bf264fd31ea19cdd8b8ba71e4af68d8264789c1534c23939bd56b3a5b0092c52d315ecc5f1b
-  languageName: node
-  linkType: hard
-
 "globby@npm:^11.0.1":
   version: 11.0.1
   resolution: "globby@npm:11.0.1"
@@ -3187,13 +3126,6 @@ __metadata:
     p-cancelable: "npm:^2.0.0"
     responselike: "npm:^2.0.0"
   checksum: 1e71c1c6b7b9e3f5a8337f8ddeb7112d911b253229243c56ffe36bdfa9149f9e0988dac553cba9e0b6007a9c45cb0cea51dda1f2168dc459f2a166dad6c5097d
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0":
-  version: 4.2.9
-  resolution: "graceful-fs@npm:4.2.9"
-  checksum: 2a66760ce6677ca18a24a1ef15d440cfd970086446af1e78c9e9de083c48122d8bd9c3fdc37f8f80f34aae833fa0d9dd52725e75a1c3f433ddd34eece39e7376
   languageName: node
   linkType: hard
 
@@ -3337,17 +3269,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "ignore@npm:5.2.0"
-  checksum: 7fb7b4c4c52c2555113ff968f8a83b8ac21b076282bfcb3f468c3fb429be69bd56222306c31de95dd452c647fc6ae24339b8047ebe3ef34c02591abfec58da01
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.1.4":
   version: 5.1.8
   resolution: "ignore@npm:5.1.8"
   checksum: 3d09e733049c7bad1c0982be8fe3e767bd7b756dd0bfeceff11acda0b7b57634b5516acc3554d2d536e64b2701b3d08d0e5fa4dbf46389847dd3f8fa49d437bb
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "ignore@npm:5.2.0"
+  checksum: 7fb7b4c4c52c2555113ff968f8a83b8ac21b076282bfcb3f468c3fb429be69bd56222306c31de95dd452c647fc6ae24339b8047ebe3ef34c02591abfec58da01
   languageName: node
   linkType: hard
 
@@ -3527,13 +3459,6 @@ __metadata:
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: cf7d4ac35fb96bab6a1d2c3598fe5ebb29aafb52c0aaa482b5a3ed9d8ba3edc11631e3ec2637660c44b3ce0e61a08d54946e8af30dec0b60a7c27296c68ffd05
-  languageName: node
-  linkType: hard
-
-"is-plain-object@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "is-plain-object@npm:3.0.1"
-  checksum: eac88599d3f030b313aa5a12d09bd3c52ce3b8cd975b2fdda6bb3bb69ac0bc1b93cd292123769eb480b914d1dd1fed7633cdeb490458d41294eb32efdedec230
   languageName: node
   linkType: hard
 
@@ -4218,18 +4143,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jsonfile@npm:4.0.0"
-  dependencies:
-    graceful-fs: "npm:^4.1.6"
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
-  languageName: node
-  linkType: hard
-
 "jsprim@npm:^1.2.2":
   version: 1.4.1
   resolution: "jsprim@npm:1.4.1"
@@ -4415,7 +4328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.2.3, merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
@@ -5284,19 +5197,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-copy@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "rollup-plugin-copy@npm:3.4.0"
-  dependencies:
-    "@types/fs-extra": "npm:^8.0.1"
-    colorette: "npm:^1.1.0"
-    fs-extra: "npm:^8.1.0"
-    globby: "npm:10.0.1"
-    is-plain-object: "npm:^3.0.0"
-  checksum: edcf97209d21ab38334e2355b04be3f98c4882761994e9fb4e7ec5f8aecf7843a06f84485c6cfd951d7e995fbfec1108341c259a3cfc0d56036e96df3caa9aac
-  languageName: node
-  linkType: hard
-
 "rollup-plugin-multi-input@npm:^1.3.1":
   version: 1.3.1
   resolution: "rollup-plugin-multi-input@npm:1.3.1"
@@ -5994,13 +5894,6 @@ __metadata:
   version: 1.12.0
   resolution: "underscore@npm:1.12.0"
   checksum: 956e17e50c145504b2d59681358bcbfd4b80674c7334455dfefee313f9775e72b9504b603aa53e8199d88649377045e7a32a519ea0cebe0481d8950d6f04a0e5
-  languageName: node
-  linkType: hard
-
-"universalify@npm:^0.1.0":
-  version: 0.1.2
-  resolution: "universalify@npm:0.1.2"
-  checksum: e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/arcanis/clipanion/pull/120 caused `./lib/advanced/Cli.mjs` to contain an unqualified import to the `platform` folder instead of the files in it.

Fixes https://github.com/nodejs/corepack/pull/349#discussion_r1443780153

**How did you fix it?**

Import the `node` platform directly, remove the `sources/platform/package.json` file, and add a `browser` and `module` field to the `publishConfig`.

This let's bundlers pick the `module` version and if they're bundling for a browser replace `./lib/platform/node*` with `./lib/platform/browser*`.