### PR TITLE
Update help.md with correct --help usage

### DIFF
--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -76,9 +76,9 @@ A second example
   $ my-app my-command --with-parameter
 ```
 
-## The `help` command
+## The `--help` flag
 
-The builtin `help` command prints the list of available commands. To add it, simply import and register it:
+The builtin `--help` flag prints the list of available commands. To add it, simply import and register it:
 
 ```ts
 import {Cli, Builtins} from "clipanion";
@@ -93,7 +93,7 @@ cli.register(Builtins.HelpCommand);
 ```
 
 ```
-$ my-app help
+$ my-app --help
 ```
 
 ```


### PR DESCRIPTION
The documentation isn't aligned with the builtin `help`.

The [Builtin doc](https://mael.dev/clipanion/docs/api/builtins/#builtinshelpcommand) talks about a `--help` flag.

But the [Help command doc](https://mael.dev/clipanion/docs/help#the-help-command) talks about a full fledged `help` command.

Spoiler alert, the `help` command doesn't work and prints an error.
The `--help` flag is what works.

This PR fixes this and update the [Help command doc](https://mael.dev/clipanion/docs/help#the-help-command).

> [!WARNING]
> I'm not sure how the `#the-help-command` will be updated, or if it's in use somewhere else.

> [!NOTE]
> The <kbd>Edit this page</kbd> link isn't working as expected.