### PR TITLE
Add key and initialValue to option definition

### DIFF
--- a/sources/advanced/Command.ts
+++ b/sources/advanced/Command.ts
@@ -59,11 +59,13 @@ export type Definition = Usage & {
    * The various options registered on the command.
    */
   options: Array<{
+    key: string;
     preferredName: string;
     nameSet: Array<string>;
     definition: string;
     description?: string;
     required: boolean;
+    initialValue: any;
   }>;
 };
 

--- a/sources/advanced/options/Array.ts
+++ b/sources/advanced/options/Array.ts
@@ -26,8 +26,9 @@ export function Array<T = string, Arity extends number = 1>(descriptor: string, 
   const nameSet = new Set(optNames);
 
   return makeCommandOption({
-    definition(builder) {
+    definition(builder, key) {
       builder.addOption({
+        key,
         names: optNames,
 
         arity,
@@ -35,6 +36,7 @@ export function Array<T = string, Arity extends number = 1>(descriptor: string, 
         hidden: opts?.hidden,
         description: opts?.description,
         required: opts.required,
+        initialValue,
       });
     },
 

--- a/sources/advanced/options/Boolean.ts
+++ b/sources/advanced/options/Boolean.ts
@@ -19,8 +19,9 @@ export function Boolean(descriptor: string, initialValueBase: BooleanFlags | boo
   const nameSet = new Set(optNames);
 
   return makeCommandOption({
-    definition(builder) {
+    definition(builder, key) {
       builder.addOption({
+        key,
         names: optNames,
 
         allowBinding: false,
@@ -29,10 +30,11 @@ export function Boolean(descriptor: string, initialValueBase: BooleanFlags | boo
         hidden: opts.hidden,
         description: opts.description,
         required: opts.required,
+        initialValue,
       });
     },
 
-    transformer(builer, key, state) {
+    transformer(builder, key, state) {
       let currentValue = initialValue;
 
       for (const {name, value} of state.options) {

--- a/sources/advanced/options/Counter.ts
+++ b/sources/advanced/options/Counter.ts
@@ -20,8 +20,9 @@ export function Counter(descriptor: string, initialValueBase: CounterFlags | num
   const nameSet = new Set(optNames);
 
   return makeCommandOption({
-    definition(builder) {
+    definition(builder, key) {
       builder.addOption({
+        key,
         names: optNames,
 
         allowBinding: false,
@@ -30,6 +31,7 @@ export function Counter(descriptor: string, initialValueBase: CounterFlags | num
         hidden: opts.hidden,
         description: opts.description,
         required: opts.required,
+        initialValue,
       });
     },
 

--- a/sources/advanced/options/Proxy.ts
+++ b/sources/advanced/options/Proxy.ts
@@ -22,6 +22,7 @@ export function Proxy(opts: ProxyFlags = {}) {
   return makeCommandOption({
     definition(builder, key) {
       builder.addProxy({
+        key,
         name: opts.name ?? key,
         required: opts.required,
       });

--- a/sources/advanced/options/Rest.ts
+++ b/sources/advanced/options/Rest.ts
@@ -24,6 +24,7 @@ export function Rest(opts: RestFlags = {}) {
   return makeCommandOption({
     definition(builder, key) {
       builder.addRest({
+        key,
         name: opts.name ?? key,
         required: opts.required,
       });

--- a/sources/advanced/options/String.ts
+++ b/sources/advanced/options/String.ts
@@ -42,8 +42,9 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
   const nameSet = new Set(optNames);
 
   return makeCommandOption({
-    definition(builder) {
+    definition(builder, key) {
       builder.addOption({
+        key,
         names: optNames,
 
         arity: opts.tolerateBoolean ? 0 : arity,
@@ -51,6 +52,7 @@ function StringOption<T = string, Arity extends number = 1>(descriptor: string, 
         hidden: opts.hidden,
         description: opts.description,
         required: opts.required,
+        initialValue,
       });
     },
 
@@ -89,6 +91,7 @@ function StringPositional<T = string>(opts: StringPositionalFlags<T> = {}) {
   return makeCommandOption({
     definition(builder, key) {
       builder.addPositional({
+        key,
         name: opts.name ?? key,
         required: opts.required,
       });

--- a/tests/specs/advanced.test.ts
+++ b/tests/specs/advanced.test.ts
@@ -788,6 +788,26 @@ describe(`Advanced`, () => {
     expect(cli.usage(CommandA, {detailed: true})).toMatch(/\u001b\[1m\$ \u001b\[22m\.\.\. greet \[--message #0\]\n\n\u001b\[1m━━━ Options .*\n\n +\S*--verbose *\S* +Log output\n +\S*--output #0 *\S* +The output directory\n/);
   });
 
+
+  it(`should print flags with a description and/or initialValue separately`, async () => {
+    class CommandA extends Command {
+      verbose = Option.Boolean(`--verbose`, {description: `Log output`});
+      output = Option.String(`--output`, {description: `The output directory`});
+      message = Option.String(`--message`, `Hello world`);
+      recipient = Option.String(`--recipient`, `Bob`, {description: `The greeting's recipient`});
+
+      static paths = [[`greet`]];
+      async execute() {
+        throw new Error(`not implemented, just testing usage()`);
+      }
+    }
+
+    const cli = Cli.from([CommandA]);
+
+    // eslint-disable-next-line no-control-regex
+    expect(cli.usage(CommandA, {detailed: true})).toMatch(/\u001b\[1m\$ \u001b\[22m\.\.\. greet\n\n\u001b\[1m━━━ Options .*\n\n +\S*--verbose *\S* +Log output\n +\S*--output #0 *\S* +The output directory\n +\S*--message #0 *\S* +\[default: Hello world\]\n +\S*--recipient #0 *\S* +The greeting's recipient \[default: Bob\]\n/);
+  });
+
   it(`should support tuples`, async () => {
     class PointCommand extends Command {
       point = Option.String(`--point`, {arity: 3});

--- a/tests/specs/core.test.ts
+++ b/tests/specs/core.test.ts
@@ -23,8 +23,8 @@ describe(`Core`, () => {
   it(`should select the default command when using mandatory positional arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
-        b.addPositional();
+        b.addPositional({key: `x`});
+        b.addPositional({key: `y`});
       },
     ]);
 
@@ -55,7 +55,7 @@ describe(`Core`, () => {
         // Nothing to do
       },
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -66,10 +66,10 @@ describe(`Core`, () => {
   it(`should select commands by their simple options`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`]});
+        b.addOption({key: `x`, names: [`-x`]});
       },
       b => {
-        b.addOption({names: [`-y`]});
+        b.addOption({key: `y`, names: [`-y`]});
       },
     ]);
 
@@ -84,11 +84,11 @@ describe(`Core`, () => {
     const cli = makeCli([
       b => {
         b.addPath([`foo`]);
-        b.addOption({names: [`-x`]});
+        b.addOption({key: `x`, names: [`-x`]});
       },
       b => {
         b.addPath([`bar`]);
-        b.addOption({names: [`-y`]});
+        b.addOption({key: `y`, names: [`-y`]});
       },
     ]);
 
@@ -102,10 +102,10 @@ describe(`Core`, () => {
   it(`should select commands by their complex values`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`], arity: 1});
+        b.addOption({key: `x`, names: [`-x`], arity: 1});
       },
       b => {
-        b.addOption({names: [`-y`], arity: 1});
+        b.addOption({key: `y`, names: [`-y`], arity: 1});
       },
     ]);
 
@@ -122,7 +122,7 @@ describe(`Core`, () => {
         b.addPath([`foo`]);
       },
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -133,7 +133,7 @@ describe(`Core`, () => {
   it(`should prefer longer paths over mandatory arguments (reversed)`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
       b => {
         b.addPath([`foo`]);
@@ -151,7 +151,7 @@ describe(`Core`, () => {
       },
       b => {
         b.addPath([`prfx`]);
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -165,7 +165,7 @@ describe(`Core`, () => {
         b.addPath([`foo`]);
       },
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
     ]);
 
@@ -176,7 +176,7 @@ describe(`Core`, () => {
   it(`should prefer longer paths over optional arguments (reversed)`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
       b => {
         b.addPath([`foo`]);
@@ -194,7 +194,7 @@ describe(`Core`, () => {
       },
       b => {
         b.addPath([`prfx`]);
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
     ]);
 
@@ -205,10 +205,10 @@ describe(`Core`, () => {
   it(`should prefer mandatory arguments over optional arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `y`, required: false});
       },
     ]);
 
@@ -219,10 +219,10 @@ describe(`Core`, () => {
   it(`should prefer mandatory arguments over optional arguments (reversed)`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -236,7 +236,7 @@ describe(`Core`, () => {
         b.addPath([`foo`]);
       },
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -247,7 +247,7 @@ describe(`Core`, () => {
   it(`should fallback from path to mandatory arguments if needed (reversed)`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
       b => {
         b.addPath([`foo`]);
@@ -265,7 +265,7 @@ describe(`Core`, () => {
       },
       b => {
         b.addPath([`prfx`]);
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -279,7 +279,7 @@ describe(`Core`, () => {
         b.addPath([`foo`]);
       },
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
     ]);
 
@@ -290,7 +290,7 @@ describe(`Core`, () => {
   it(`should fallback from path to optional arguments if needed (reversed)`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
       },
       b => {
         b.addPath([`foo`]);
@@ -308,7 +308,7 @@ describe(`Core`, () => {
       },
       b => {
         b.addPath([`prfx`]);
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -319,7 +319,7 @@ describe(`Core`, () => {
   it(`should extract booleans from simple options`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`]});
+        b.addOption({key: `x`, names: [`-x`]});
       },
     ]);
 
@@ -332,8 +332,8 @@ describe(`Core`, () => {
   it(`should extract booleans from batch options`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`]});
-        b.addOption({names: [`-y`]});
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addOption({key: `y`, names: [`-y`]});
       },
     ]);
 
@@ -347,7 +347,7 @@ describe(`Core`, () => {
   it(`should invert booleans when using --no-`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`]});
+        b.addOption({key: `foo`, names: [`--foo`]});
       },
     ]);
 
@@ -360,7 +360,7 @@ describe(`Core`, () => {
   it(`should extract strings from complex options`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`], arity: 1});
+        b.addOption({key: `x`, names: [`-x`], arity: 1});
       },
     ]);
 
@@ -373,7 +373,7 @@ describe(`Core`, () => {
   it(`should extract strings from complex options (=)`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], arity: 1});
+        b.addOption({key: `foo`, names: [`--foo`], arity: 1});
       },
     ]);
 
@@ -386,7 +386,7 @@ describe(`Core`, () => {
   it(`shouldn't consider '-' as an option`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], arity: 1});
+        b.addOption({key: `foo`, names: [`--foo`], arity: 1});
       },
     ]);
 
@@ -399,7 +399,7 @@ describe(`Core`, () => {
   it(`should extract arrays from complex options`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], arity: 1});
+        b.addOption({key: `foo`, names: [`--foo`], arity: 1});
       },
     ]);
 
@@ -413,7 +413,7 @@ describe(`Core`, () => {
   it(`should extract arrays from complex options (=)`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], arity: 1});
+        b.addOption({key: `foo`, names: [`--foo`], arity: 1});
       },
     ]);
 
@@ -427,7 +427,7 @@ describe(`Core`, () => {
   it(`should extract arrays from complex options (mixed)`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], arity: 1});
+        b.addOption({key: `foo`, names: [`--foo`], arity: 1});
       },
     ]);
 
@@ -441,7 +441,7 @@ describe(`Core`, () => {
   it(`should support rest arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addRest();
+        b.addRest({key: `x`});
       },
     ]);
 
@@ -456,8 +456,8 @@ describe(`Core`, () => {
   it(`should support rest arguments followed by mandatory arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addRest();
-        b.addPositional();
+        b.addRest({key: `x`});
+        b.addPositional({key: `y`});
       },
     ]);
 
@@ -473,9 +473,9 @@ describe(`Core`, () => {
   it(`should support rest arguments between mandatory arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
-        b.addRest();
-        b.addPositional();
+        b.addPositional({key: `x`});
+        b.addRest({key: `y`});
+        b.addPositional({key: `z`});
       },
     ]);
 
@@ -492,9 +492,9 @@ describe(`Core`, () => {
   it(`should support option arguments in between rest arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`]});
-        b.addOption({names: [`--bar`], arity: 1});
-        b.addRest();
+        b.addOption({key: `foo`, names: [`--foo`]});
+        b.addOption({key: `bar`, names: [`--bar`], arity: 1});
+        b.addRest({key: `x`});
       },
     ]);
 
@@ -516,8 +516,8 @@ describe(`Core`, () => {
     const cli = makeCli([
       b => {
         b.addPath([`foo`]);
-        b.addOption({names: [`-x`]});
-        b.addPositional({required: false});
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addPositional({key: `y`, required: false});
       },
     ]);
 
@@ -535,9 +535,9 @@ describe(`Core`, () => {
     const cli = makeCli([
       b => {
         b.addPath([`foo`]);
-        b.addOption({names: [`-x`]});
-        b.addPositional();
-        b.addProxy();
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addPositional({key: `y`});
+        b.addProxy({key: `z`});
       },
     ]);
 
@@ -556,10 +556,10 @@ describe(`Core`, () => {
     const cli = makeCli([
       b => {
         b.addPath([`foo`]);
-        b.addOption({names: [`-x`]});
-        b.addPositional();
-        b.addPositional();
-        b.addProxy();
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addPositional({key: `y`});
+        b.addPositional({key: `z`});
+        b.addProxy({key: `a`});
       },
     ]);
 
@@ -580,8 +580,8 @@ describe(`Core`, () => {
     const cli = makeCli([
       b => {
         b.addPath([`foo`]);
-        b.addOption({names: [`-x`]});
-        b.addProxy();
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addProxy({key: `y`});
       },
     ]);
 
@@ -603,7 +603,7 @@ describe(`Core`, () => {
       },
       b => {
         b.addPath([`foo`]);
-        b.addProxy({required: 1});
+        b.addProxy({key: `x`, required: 1});
       },
     ]);
 
@@ -614,12 +614,12 @@ describe(`Core`, () => {
   it(`should aggregate the options as they are found`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`-x`]});
-        b.addOption({names: [`-y`]});
-        b.addOption({names: [`-z`]});
-        b.addOption({names: [`-u`], arity: 1});
-        b.addOption({names: [`-v`], arity: 1});
-        b.addOption({names: [`-w`], arity: 1});
+        b.addOption({key: `x`, names: [`-x`]});
+        b.addOption({key: `y`, names: [`-y`]});
+        b.addOption({key: `z`, names: [`-z`]});
+        b.addOption({key: `u`,  names: [`-u`], arity: 1});
+        b.addOption({key: `v`, names: [`-v`], arity: 1});
+        b.addOption({key: `w`, names: [`-w`], arity: 1});
       },
     ]);
 
@@ -643,8 +643,8 @@ describe(`Core`, () => {
   it(`should aggregate the mandatory arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
-        b.addPositional();
+        b.addPositional({key: `x`});
+        b.addPositional({key: `y`});
       },
     ]);
 
@@ -658,8 +658,8 @@ describe(`Core`, () => {
   it(`should aggregate the optional arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional({required: false});
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
+        b.addPositional({key: `y`, required: false});
       },
     ]);
 
@@ -673,8 +673,8 @@ describe(`Core`, () => {
   it(`should accept as few optional arguments as possible`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional({required: false});
-        b.addPositional({required: false});
+        b.addPositional({key: `x`, required: false});
+        b.addPositional({key: `y`, required: false});
       },
     ]);
 
@@ -690,8 +690,8 @@ describe(`Core`, () => {
   it(`should accept a mix of mandatory and optional arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
-        b.addPositional({required: false});
+        b.addPositional({key: `x`});
+        b.addPositional({key: `y`, required: false});
       },
     ]);
 
@@ -710,7 +710,7 @@ describe(`Core`, () => {
   it(`should accept any option as positional argument when proxies are enabled`, () => {
     const cli = makeCli([
       b => {
-        b.addProxy();
+        b.addProxy({key: `x`});
       },
     ]);
 
@@ -785,7 +785,7 @@ describe(`Core`, () => {
   it(`should throw acceptable errors when omitting mandatory positional arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addPositional();
+        b.addPositional({key: `x`});
       },
     ]);
 
@@ -809,7 +809,7 @@ describe(`Core`, () => {
   it(`should throw acceptable errors when writing bound boolean arguments`, () => {
     const cli = makeCli([
       b => {
-        b.addOption({names: [`--foo`], allowBinding: false});
+        b.addOption({key: `foo`, names: [`--foo`], allowBinding: false});
       },
     ]);
 


### PR DESCRIPTION
The `key` allows mapping an option definition to a class variable. The `initialValue` is used to show the default value in a command's usage output.

We want to generate command documentation from code.  Both properties come in handy in this case.

I'm open to any suggestions/improvements.